### PR TITLE
🔒 Fix: Add rel='noopener noreferrer' to target='_blank' links

### DIFF
--- a/cv.html
+++ b/cv.html
@@ -65,6 +65,7 @@
               href="https://aidelab.arizona.edu/"
               class="nav-link"
               target="_blank"
+              rel="noopener noreferrer"
               >AIDE Lab
               <i
                 class="fas fa-external-link-alt"
@@ -159,7 +160,8 @@
           >
             <p>
               If the PDF does not load, you can
-              <a href="michler_cv.pdf" target="_blank">view it directly here</a
+              <a href="michler_cv.pdf" target="_blank" rel="noopener noreferrer"
+                >view it directly here</a
               >.
             </p>
           </div>
@@ -200,12 +202,14 @@
             href="https://economics.arizona.edu/person/jeffrey-d-michler"
             title="Departmental Website"
             target="_blank"
+            rel="noopener noreferrer"
             ><i class="fas fa-university"></i
           ></a>
           <a
             href="https://orcid.org/0000-0001-7778-8703"
             title="ORCiD"
             target="_blank"
+            rel="noopener noreferrer"
             ><i class="fab fa-orcid"></i
           ></a>
           <!-- Update this google scholar link when ready -->
@@ -213,9 +217,14 @@
             href="https://scholar.google.com/citations?user=your_id_here"
             title="Google Scholar"
             target="_blank"
+            rel="noopener noreferrer"
             ><i class="fas fa-graduation-cap"></i
           ></a>
-          <a href="https://github.com/jdavidm" title="GitHub" target="_blank"
+          <a
+            href="https://github.com/jdavidm"
+            title="GitHub"
+            target="_blank"
+            rel="noopener noreferrer"
             ><i class="fab fa-github"></i
           ></a>
         </div>

--- a/fix_rel.py
+++ b/fix_rel.py
@@ -1,0 +1,36 @@
+import re
+import glob
+
+for filename in glob.glob('*.html'):
+    with open(filename, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    # We want to replace target="_blank" with target="_blank" rel="noopener noreferrer"
+    # First, let's remove existing rel="noopener noreferrer" or rel="noopener" to avoid duplicates
+    content = re.sub(r'target="_blank"\s+rel="noopener noreferrer"', 'target="_blank"', content)
+    content = re.sub(r'target="_blank"\s+rel="noopener"', 'target="_blank"', content)
+
+    # Also handle if rel comes before target?
+    # Better approach: find all <a ...> tags and modify them.
+
+    def process_match(match):
+        tag = match.group(0)
+        if 'target="_blank"' in tag:
+            # Remove any existing rel attribute to simplify (assuming no other rel is needed like 'nofollow')
+            # Let's just remove rel="noopener noreferrer" specifically
+            tag = tag.replace('rel="noopener noreferrer"', '')
+            tag = tag.replace('rel="noopener"', '')
+            # Now add it after target="_blank"
+            tag = tag.replace('target="_blank"', 'target="_blank" rel="noopener noreferrer"')
+            # clean up multiple spaces
+            tag = re.sub(r'\s+', ' ', tag)
+            tag = tag.replace(' >', '>')
+            # restore newlines if we messed them up? The regex r'<a[^>]+>' might match across newlines
+            # If we just replace inside the tag, it's fine.
+        return tag
+
+    # regex to match <a ...>
+    content = re.sub(r'<a\s+[^>]+>', process_match, content)
+
+    with open(filename, 'w', encoding='utf-8') as f:
+        f.write(content)

--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
               href="https://aidelab.arizona.edu/"
               class="nav-link"
               target="_blank"
+              rel="noopener noreferrer"
               >AIDE Lab
               <i
                 class="fas fa-external-link-alt"
@@ -114,6 +115,7 @@
                 <a
                   href="https://onlinelibrary.wiley.com/journal/14678276"
                   target="_blank"
+                  rel="noopener noreferrer"
                   class="badge badge-link"
                   >Associate Editor, American Journal of Agricultural Economics
                   (2026-)</a
@@ -121,6 +123,7 @@
                 <a
                   href="https://academic.oup.com/erae"
                   target="_blank"
+                  rel="noopener noreferrer"
                   class="badge badge-link"
                   >Associate Editor, European Review of Agricultural Economics
                   (2024-)</a
@@ -128,6 +131,7 @@
                 <a
                   href="https://onlinelibrary.wiley.com/journal/15740862"
                   target="_blank"
+                  rel="noopener noreferrer"
                   class="badge badge-link"
                   >Associate Editor, Agricultural Economics (2023-)</a
                 >
@@ -227,6 +231,7 @@
                 class="btn btn-outline-dark"
                 style="margin-top: auto"
                 target="_blank"
+                rel="noopener noreferrer"
                 >View on Routledge
                 <i
                   class="fas fa-external-link-alt"
@@ -267,21 +272,28 @@
             href="https://economics.arizona.edu/person/jeffrey-d-michler"
             title="Departmental Website"
             target="_blank"
+            rel="noopener noreferrer"
             ><i class="fas fa-university"></i
           ></a>
           <a
             href="https://orcid.org/0000-0001-7778-8703"
             title="ORCiD"
             target="_blank"
+            rel="noopener noreferrer"
             ><i class="fab fa-orcid"></i
           ></a>
           <a
             href="https://scholar.google.com/citations?user=your_id_here"
             title="Google Scholar"
             target="_blank"
+            rel="noopener noreferrer"
             ><i class="fas fa-graduation-cap"></i
           ></a>
-          <a href="https://github.com/jdavidm" title="GitHub" target="_blank"
+          <a
+            href="https://github.com/jdavidm"
+            title="GitHub"
+            target="_blank"
+            rel="noopener noreferrer"
             ><i class="fab fa-github"></i
           ></a>
         </div>

--- a/publications.html
+++ b/publications.html
@@ -126,6 +126,7 @@
               href="https://aidelab.arizona.edu/"
               class="nav-link"
               target="_blank"
+              rel="noopener noreferrer"
               >AIDE Lab
               <i
                 class="fas fa-external-link-alt"
@@ -189,6 +190,7 @@
               <a
                 href="https://www.routledge.com/Research-Ethics-in-Applied-Economics-A-Practical-Guide/Josephson-Michler/p/book/9780367457419"
                 target="_blank"
+                rel="noopener noreferrer"
                 ><i class="fas fa-external-link-alt"></i> Published Version</a
               >
             </div>
@@ -249,6 +251,7 @@
               <a
                 href="https://doi.org/10.1016/j.jdeveco.2025.103648"
                 target="_blank"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -288,11 +291,13 @@
               <a
                 href="https://doi.org/10.1016/j.jdeveco.2025.103553"
                 target="_blank"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
               <a
                 href="http://documents.worldbank.org/curated/en/099850401072516334/IDU16cb26542195d814cc21b3191ae81d19d57ec"
                 target="_blank"
+                rel="noopener noreferrer"
                 ><i class="fas fa-file-pdf"></i> Working Paper</a
               >
             </div>
@@ -330,7 +335,10 @@
               American Journal of Agricultural Economics (2025)
             </p>
             <div class="pub-links">
-              <a href="https://doi.org/10.1111/ajae.70026" target="_blank"
+              <a
+                href="https://doi.org/10.1111/ajae.70026"
+                target="_blank"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -370,11 +378,13 @@
               <a
                 href="https://doi.org/10.1016/j.foodpol.2025.102819"
                 target="_blank"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
               <a
                 href="http://documents.worldbank.org/curated/en/099830101072519538/IDU1b45f8bf4104061493a18b9e12cfbee039761"
                 target="_blank"
+                rel="noopener noreferrer"
                 ><i class="fas fa-file-pdf"></i> Working Paper</a
               >
             </div>
@@ -411,7 +421,10 @@
               Applied Economics Teaching Resources 7 (2025)
             </p>
             <div class="pub-links">
-              <a href="https://doi.org/10.71162/aetr.369516" target="_blank"
+              <a
+                href="https://doi.org/10.71162/aetr.369516"
+                target="_blank"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -451,6 +464,7 @@
               <a
                 href="https://doi.org/10.1016/j.jdeveco.2022.102927"
                 target="_blank"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -490,6 +504,7 @@
               <a
                 href="https://doi.org/10.1016/j.foodpol.2022.102306"
                 target="_blank"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -524,7 +539,10 @@
               (2022)
             </p>
             <div class="pub-links">
-              <a href="https://doi.org/10.1002/jaa2.9" target="_blank"
+              <a
+                href="https://doi.org/10.1002/jaa2.9"
+                target="_blank"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -561,11 +579,13 @@
               <a
                 href="https://www.nature.com/articles/s41562-021-01096-7"
                 target="_blank"
+                rel="noopener noreferrer"
                 ><i class="fas fa-external-link-alt"></i> Link</a
               >
               <a
                 href="https://openknowledge.worldbank.org/handle/10986/34733"
                 target="_blank"
+                rel="noopener noreferrer"
                 ><i class="fas fa-file-pdf"></i> Working Paper</a
               >
             </div>
@@ -605,9 +625,13 @@
               <a
                 href="https://doi.org/10.1016/j.jdeveco.2021.102626"
                 target="_blank"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
-              <a href="https://www.nber.org/papers/w25665.pdf" target="_blank"
+              <a
+                href="https://www.nber.org/papers/w25665.pdf"
+                target="_blank"
+                rel="noopener noreferrer"
                 ><i class="fas fa-file-pdf"></i> Working Paper</a
               >
             </div>
@@ -644,7 +668,10 @@
               American Journal of Agricultural Economics 103 (2021)
             </p>
             <div class="pub-links">
-              <a href="https://doi.org/10.1111/ajae.12151" target="_blank"
+              <a
+                href="https://doi.org/10.1111/ajae.12151"
+                target="_blank"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -681,7 +708,10 @@
               Applied Economic Perspectives and Policy 43 (2021)
             </p>
             <div class="pub-links">
-              <a href="https://doi.org/10.1002/aepp.13132" target="_blank"
+              <a
+                href="https://doi.org/10.1002/aepp.13132"
+                target="_blank"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -701,7 +731,10 @@
               Applied Economic Perspectives and Policy 43 (2021)
             </p>
             <div class="pub-links">
-              <a href="https://doi.org/10.1002/aepp.13133" target="_blank"
+              <a
+                href="https://doi.org/10.1002/aepp.13133"
+                target="_blank"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -725,6 +758,7 @@
               <a
                 href="https://doi.org/10.1016/j.jebo.2020.09.031"
                 target="_blank"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -761,6 +795,7 @@
               <a
                 href="https://doi.org/10.1016/j.worlddev.2020.104888"
                 target="_blank"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -783,6 +818,7 @@
               <a
                 href="https://doi.org/10.1146/annurev-resource-101719-034514"
                 target="_blank"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -819,7 +855,10 @@
               American Journal of Agricultural Economics 101 (2019)
             </p>
             <div class="pub-links">
-              <a href="https://doi.org/10.1093/ajae/aay050" target="_blank"
+              <a
+                href="https://doi.org/10.1093/ajae/aay050"
+                target="_blank"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -858,6 +897,7 @@
               <a
                 href="https://doi.org/10.1016/j.jeem.2018.11.008"
                 target="_blank"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -878,7 +918,10 @@
               Applied Economic Perspectives and Policy 41 (2019)
             </p>
             <div class="pub-links">
-              <a href="https://doi.org/10.1093/aepp/ppz010" target="_blank"
+              <a
+                href="https://doi.org/10.1093/aepp/ppz010"
+                target="_blank"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -915,6 +958,7 @@
               <a
                 href="https://doi.org/10.1016/j.foodpol.2018.08.001"
                 target="_blank"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -972,6 +1016,7 @@
               <a
                 href="https://doi.org/10.1016/j.worlddev.2016.08.011"
                 target="_blank"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -992,7 +1037,10 @@
               Agricultural Economics 48 (2017)
             </p>
             <div class="pub-links">
-              <a href="https://doi.org/10.1111/agec.12320" target="_blank"
+              <a
+                href="https://doi.org/10.1111/agec.12320"
+                target="_blank"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -1018,6 +1066,7 @@
               <a
                 href="https://doi.org/10.1016/j.foodpol.2016.11.007"
                 target="_blank"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -1038,7 +1087,10 @@
               Journal of Agricultural Economics 66 (2015)
             </p>
             <div class="pub-links">
-              <a href="https://doi.org/10.1111/1477-9552.12082" target="_blank"
+              <a
+                href="https://doi.org/10.1111/1477-9552.12082"
+                target="_blank"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -1053,113 +1105,233 @@
           <a
             href="https://scholar.google.com/citations?user=your_id_here"
             target="_blank"
+            rel="noopener noreferrer"
             class="btn btn-primary"
             style="margin-top: 1rem"
             >View Google Scholar</a
           >
         </div>
 
-      <!-- Book Chapters Section -->
-      <h2 class="section-title" style="margin-top: 3rem;">Book Chapters</h2>
-      <div class="pub-grid animate-on-scroll">
-        <div class="pub-card" data-category="book">
-          <span class="card-tag" style="background-color: var(--color-accent); color: white;">Book Chapter</span>
-          <h3 class="pub-title">Recent Developments in Inference: Practicalities for the Applied Economist</h3>
-          <p class="pub-authors">Michler, J.D. and A. Josephson. 2022.</p>
-          <p class="pub-journal">In J. Roosen and J.E. Hobbs, eds., A Modern Guide to Food Economics. Cheltenham: Edward Elgar Publishing.</p>
-          <div class="pub-links">
-              <a href="https://doi.org/10.4337/9781800372054.00019" target="_blank" rel="noopener noreferrer"><i class="fas fa-external-link-alt"></i> View Chapter</a>
+        <!-- Book Chapters Section -->
+        <h2 class="section-title" style="margin-top: 3rem">Book Chapters</h2>
+        <div class="pub-grid animate-on-scroll">
+          <div class="pub-card" data-category="book">
+            <span
+              class="card-tag"
+              style="background-color: var(--color-accent); color: white"
+              >Book Chapter</span
+            >
+            <h3 class="pub-title">
+              Recent Developments in Inference: Practicalities for the Applied
+              Economist
+            </h3>
+            <p class="pub-authors">Michler, J.D. and A. Josephson. 2022.</p>
+            <p class="pub-journal">
+              In J. Roosen and J.E. Hobbs, eds., A Modern Guide to Food
+              Economics. Cheltenham: Edward Elgar Publishing.
+            </p>
+            <div class="pub-links">
+              <a
+                href="https://doi.org/10.4337/9781800372054.00019"
+                target="_blank"
+                rel="noopener noreferrer"
+                ><i class="fas fa-external-link-alt"></i> View Chapter</a
+              >
+            </div>
+          </div>
+          <div class="pub-card" data-category="book">
+            <span
+              class="card-tag"
+              style="background-color: var(--color-accent); color: white"
+              >Book Chapter</span
+            >
+            <h3 class="pub-title">
+              The Evolving Impact of COVID-19 in Four African Countries
+            </h3>
+            <p class="pub-authors">
+              Furbush, A., A. Josephson, T. Kilic, and J.D. Michler. 2021.
+            </p>
+            <p class="pub-journal">
+              In R. Arezki, S. Djankov, and U. Panizza, eds., Shaping Africa’s
+              Post-Covid Recovery. London: CEPR Press.
+            </p>
+            <div class="pub-links">
+              <a
+                href="https://voxeu.org/content/shaping-africa-s-post-covid-recovery"
+                target="_blank"
+                rel="noopener noreferrer"
+                ><i class="fas fa-external-link-alt"></i> View Chapter</a
+              >
+              <a
+                href="https://documents.worldbank.org/en/publication/documents-reports/documentdetail/810651614623398314/the-evolving-socioeconomic-impacts-of-covid-19-in-four-african-countries"
+                target="_blank"
+                rel="noopener noreferrer"
+                ><i class="fas fa-file-pdf"></i> Working Paper</a
+              >
+            </div>
           </div>
         </div>
-        <div class="pub-card" data-category="book">
-          <span class="card-tag" style="background-color: var(--color-accent); color: white;">Book Chapter</span>
-          <h3 class="pub-title">The Evolving Impact of COVID-19 in Four African Countries</h3>
-          <p class="pub-authors">Furbush, A., A. Josephson, T. Kilic, and J.D. Michler. 2021.</p>
-          <p class="pub-journal">In R. Arezki, S. Djankov, and U. Panizza, eds., Shaping Africa’s Post-Covid Recovery. London: CEPR Press.</p>
-          <div class="pub-links">
-              <a href="https://voxeu.org/content/shaping-africa-s-post-covid-recovery" target="_blank" rel="noopener noreferrer"><i class="fas fa-external-link-alt"></i> View Chapter</a>
-              <a href="https://documents.worldbank.org/en/publication/documents-reports/documentdetail/810651614623398314/the-evolving-socioeconomic-impacts-of-covid-19-in-four-african-countries" target="_blank" rel="noopener noreferrer"><i class="fas fa-file-pdf"></i> Working Paper</a>
+
+        <!-- Working Papers Section -->
+        <h2 class="section-title" style="margin-top: 3rem">Working Papers</h2>
+        <div class="pub-grid animate-on-scroll">
+          <div class="pub-card" data-category="working">
+            <span
+              class="card-tag"
+              style="background-color: var(--color-secondary); color: white"
+              >Working Paper</span
+            >
+            <h3 class="pub-title">
+              The Uses (and Misuses) of Weather and Earth Observation Data in
+              Geospatial Impact Evaluations
+            </h3>
+            <p class="pub-authors">
+              Benami, E., M. Cecil, A. Josephson, G. Maskell, and J.D. Michler
+            </p>
+            <div class="pub-links">
+              <a
+                href="http://arxiv.org/abs/2510.05108"
+                target="_blank"
+                rel="noopener noreferrer"
+                ><i class="fas fa-external-link-alt"></i> View Paper</a
+              >
+            </div>
+          </div>
+          <div class="pub-card" data-category="working">
+            <span
+              class="card-tag"
+              style="background-color: var(--color-secondary); color: white"
+              >Working Paper</span
+            >
+            <h3 class="pub-title">
+              Considerations and Resources for Integrating EO and Socioeconomic
+              Data
+            </h3>
+            <p class="pub-authors">
+              Michler, J.D., E. Benami, A. Josephson, G. Maskell, M. Cecil, P.
+              Behrer, R. Heilmayr, S. Gourlay, and K.Singh
+            </p>
+          </div>
+          <div class="pub-card" data-category="working">
+            <span
+              class="card-tag"
+              style="background-color: var(--color-secondary); color: white"
+              >Working Paper</span
+            >
+            <h3 class="pub-title">
+              Mining Meaning: Conducting AI-Assisted Reviews of Economic
+              Literature
+            </h3>
+            <p class="pub-authors">
+              Michler, J.D., K. Douglas, and A. Josephson
+            </p>
+          </div>
+          <div class="pub-card" data-category="working">
+            <span
+              class="card-tag"
+              style="background-color: var(--color-secondary); color: white"
+              >Working Paper</span
+            >
+            <h3 class="pub-title">
+              Variable Selection in Socioeconomic Applications of Remotely
+              Sensed Weather Data: Insights from the LSMS-ISA
+            </h3>
+            <p class="pub-authors">
+              Michler, J.D., A. Josephson, C.D. Agme and T. Kilic
+            </p>
+          </div>
+          <div class="pub-card" data-category="working">
+            <span
+              class="card-tag"
+              style="background-color: var(--color-secondary); color: white"
+              >Working Paper</span
+            >
+            <h3 class="pub-title">
+              Labor, Credit, and Markets: Evidence from the Philippines,
+              1971-2016
+            </h3>
+            <p class="pub-authors">
+              Kee-Tui, E., A. Josephson, and J.D. Michler
+            </p>
+          </div>
+          <div class="pub-card" data-category="working">
+            <span
+              class="card-tag"
+              style="background-color: var(--color-secondary); color: white"
+              >Working Paper</span
+            >
+            <h3 class="pub-title">
+              Risk and Rainfall: Specification Sensitivity in Estimating
+              Smallholder Risk Preferences
+            </h3>
+            <p class="pub-authors">
+              Braham, R., A. Josephson, and J.D. Michler
+            </p>
+          </div>
+          <div class="pub-card" data-category="working">
+            <span
+              class="card-tag"
+              style="background-color: var(--color-secondary); color: white"
+              >Working Paper</span
+            >
+            <h3 class="pub-title">
+              Approximation in Complex Pricing Mechanisms
+            </h3>
+            <p class="pub-authors">Michler, J.D., P. Slade, and S.Y. Wu</p>
+          </div>
+          <div class="pub-card" data-category="working">
+            <span
+              class="card-tag"
+              style="background-color: var(--color-secondary); color: white"
+              >Working Paper</span
+            >
+            <h3 class="pub-title">
+              Complex Pricing and Consumer Behavior: Evidence from a Lab
+              Experiment
+            </h3>
+            <p class="pub-authors">
+              Deutschmann, J.W., J.D. Michler, and E. Tjernström
+            </p>
+          </div>
+          <div class="pub-card" data-category="working">
+            <span
+              class="card-tag"
+              style="background-color: var(--color-secondary); color: white"
+              >Working Paper</span
+            >
+            <h3 class="pub-title">
+              A Dynamic Model of Firm Location in Two-Dimensional Space
+            </h3>
+            <p class="pub-authors">Michler, J.D., S.D. Yun, and B. Gramig</p>
+          </div>
+          <div class="pub-card" data-category="working">
+            <span
+              class="card-tag"
+              style="background-color: var(--color-secondary); color: white"
+              >Working Paper</span
+            >
+            <h3 class="pub-title">
+              An Industrious Revolution? Changes in the Household Economy in
+              Rural Bangladesh
+            </h3>
+            <p class="pub-authors">Josephson, A., J.D. Michler, and A. Orr</p>
+          </div>
+          <div class="pub-card" data-category="working">
+            <span
+              class="card-tag"
+              style="background-color: var(--color-secondary); color: white"
+              >Working Paper</span
+            >
+            <h3 class="pub-title">
+              Effects of Credit and Market Access on Farm Gate Prices in India
+            </h3>
+            <p class="pub-authors">
+              Baylis, K., M. Mallory, J.D. Michler, and T. Songsermsawa
+            </p>
           </div>
         </div>
       </div>
-
-      <!-- Working Papers Section -->
-      <h2 class="section-title" style="margin-top: 3rem;">Working Papers</h2>
-      <div class="pub-grid animate-on-scroll">
-        <div class="pub-card" data-category="working">
-          <span class="card-tag" style="background-color: var(--color-secondary); color: white;">Working Paper</span>
-          <h3 class="pub-title">The Uses (and Misuses) of Weather and Earth Observation Data in Geospatial Impact Evaluations</h3>
-          <p class="pub-authors">Benami, E., M. Cecil, A. Josephson, G. Maskell, and J.D. Michler</p>
-          <div class="pub-links">
-              <a href="http://arxiv.org/abs/2510.05108" target="_blank" rel="noopener noreferrer"><i class="fas fa-external-link-alt"></i> View Paper</a>
-          </div>
-        </div>
-        <div class="pub-card" data-category="working">
-          <span class="card-tag" style="background-color: var(--color-secondary); color: white;">Working Paper</span>
-          <h3 class="pub-title">Considerations and Resources for Integrating EO and Socioeconomic Data</h3>
-          <p class="pub-authors">Michler, J.D., E. Benami, A. Josephson, G. Maskell, M. Cecil, P. Behrer, R. Heilmayr, S. Gourlay, and K.Singh</p>
-
-        </div>
-        <div class="pub-card" data-category="working">
-          <span class="card-tag" style="background-color: var(--color-secondary); color: white;">Working Paper</span>
-          <h3 class="pub-title">Mining Meaning: Conducting AI-Assisted Reviews of Economic Literature</h3>
-          <p class="pub-authors">Michler, J.D., K. Douglas, and A. Josephson</p>
-
-        </div>
-        <div class="pub-card" data-category="working">
-          <span class="card-tag" style="background-color: var(--color-secondary); color: white;">Working Paper</span>
-          <h3 class="pub-title">Variable Selection in Socioeconomic Applications of Remotely Sensed Weather Data: Insights from the LSMS-ISA</h3>
-          <p class="pub-authors">Michler, J.D., A. Josephson, C.D. Agme and T. Kilic</p>
-
-        </div>
-        <div class="pub-card" data-category="working">
-          <span class="card-tag" style="background-color: var(--color-secondary); color: white;">Working Paper</span>
-          <h3 class="pub-title">Labor, Credit, and Markets: Evidence from the Philippines, 1971-2016</h3>
-          <p class="pub-authors">Kee-Tui, E., A. Josephson, and J.D. Michler</p>
-
-        </div>
-        <div class="pub-card" data-category="working">
-          <span class="card-tag" style="background-color: var(--color-secondary); color: white;">Working Paper</span>
-          <h3 class="pub-title">Risk and Rainfall: Specification Sensitivity in Estimating Smallholder Risk Preferences</h3>
-          <p class="pub-authors">Braham, R., A. Josephson, and J.D. Michler</p>
-
-        </div>
-        <div class="pub-card" data-category="working">
-          <span class="card-tag" style="background-color: var(--color-secondary); color: white;">Working Paper</span>
-          <h3 class="pub-title">Approximation in Complex Pricing Mechanisms</h3>
-          <p class="pub-authors">Michler, J.D., P. Slade, and S.Y. Wu</p>
-
-        </div>
-        <div class="pub-card" data-category="working">
-          <span class="card-tag" style="background-color: var(--color-secondary); color: white;">Working Paper</span>
-          <h3 class="pub-title">Complex Pricing and Consumer Behavior: Evidence from a Lab Experiment</h3>
-          <p class="pub-authors">Deutschmann, J.W., J.D. Michler, and E. Tjernström</p>
-
-        </div>
-        <div class="pub-card" data-category="working">
-          <span class="card-tag" style="background-color: var(--color-secondary); color: white;">Working Paper</span>
-          <h3 class="pub-title">A Dynamic Model of Firm Location in Two-Dimensional Space</h3>
-          <p class="pub-authors">Michler, J.D., S.D. Yun, and B. Gramig</p>
-
-        </div>
-        <div class="pub-card" data-category="working">
-          <span class="card-tag" style="background-color: var(--color-secondary); color: white;">Working Paper</span>
-          <h3 class="pub-title">An Industrious Revolution? Changes in the Household Economy in Rural Bangladesh</h3>
-          <p class="pub-authors">Josephson, A., J.D. Michler, and A. Orr</p>
-
-        </div>
-        <div class="pub-card" data-category="working">
-          <span class="card-tag" style="background-color: var(--color-secondary); color: white;">Working Paper</span>
-          <h3 class="pub-title">Effects of Credit and Market Access on Farm Gate Prices in India</h3>
-          <p class="pub-authors">Baylis, K., M. Mallory, J.D. Michler, and T. Songsermsawa</p>
-
-        </div>
-      </div>
-      </div>
-
-
-
-        </main>
+    </main>
 
     <!-- Footer -->
     <footer class="footer">
@@ -1189,21 +1361,28 @@
             href="https://economics.arizona.edu/person/jeffrey-d-michler"
             title="Departmental Website"
             target="_blank"
+            rel="noopener noreferrer"
             ><i class="fas fa-university"></i
           ></a>
           <a
             href="https://orcid.org/0000-0001-7778-8703"
             title="ORCiD"
             target="_blank"
+            rel="noopener noreferrer"
             ><i class="fab fa-orcid"></i
           ></a>
           <a
             href="https://scholar.google.com/citations?user=your_id_here"
             title="Google Scholar"
             target="_blank"
+            rel="noopener noreferrer"
             ><i class="fas fa-graduation-cap"></i
           ></a>
-          <a href="https://github.com/jdavidm" title="GitHub" target="_blank"
+          <a
+            href="https://github.com/jdavidm"
+            title="GitHub"
+            target="_blank"
+            rel="noopener noreferrer"
             ><i class="fab fa-github"></i
           ></a>
         </div>

--- a/software.html
+++ b/software.html
@@ -4,7 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Software | Jeffrey D. Michler</title>
-    <meta name="description" content="Software and econometric packages by Jeffrey D. Michler." />
+    <meta
+      name="description"
+      content="Software and econometric packages by Jeffrey D. Michler."
+    />
     <!-- Google Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -42,8 +45,9 @@
               class="nav-link"
               target="_blank"
               rel="noopener noreferrer"
-              >AIDE Lab <i class="fas fa-external-link-alt" style="font-size: 0.8em"></i></a
-            >
+              >AIDE Lab
+              <i class="fas fa-external-link-alt" style="font-size: 0.8em"></i
+            ></a>
           </li>
         </ul>
       </div>
@@ -67,54 +71,104 @@
     <!-- Main Content Area -->
     <main class="section">
       <div class="container">
+        <div style="display: grid; gap: var(--spacing-lg)">
+          <!-- randcoef -->
+          <div
+            class="card"
+            style="
+              padding: var(--spacing-lg);
+              background-color: var(--color-bg-surface);
+              border-radius: var(--radius-lg);
+              box-shadow: var(--shadow-sm);
+              border: 1px solid var(--color-border);
+            "
+          >
+            <h2
+              style="
+                color: var(--color-primary);
+                margin-bottom: 1rem;
+                border-bottom: 2px solid var(--color-accent);
+                display: inline-block;
+                padding-bottom: 0.5rem;
+              "
+            >
+              randcoef
+            </h2>
+            <p
+              style="
+                font-size: 1.1rem;
+                color: var(--color-text-muted);
+                margin-bottom: 1rem;
+              "
+            >
+              <strong>Description:</strong> Correlated Random Effects Estimation
+              of the Random Coefficients Model
+            </p>
+            <p style="line-height: 1.7; margin-bottom: 1.5rem">
+              <code>randcoef</code> is a Stata module that estimates the
+              Correlated Random Effects (CRE) model for panel data. It provides
+              an alternative to traditional fixed effects or random effects by
+              allowing for correlation between the unobserved heterogeneity and
+              the observed regressors.
+            </p>
+            <a
+              href="https://ideas.repec.org/c/boc/bocode/s458514.html"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="btn btn-primary"
+            >
+              <i class="fas fa-external-link-alt"></i> View on IDEAS/RePEc
+            </a>
+          </div>
 
-        <div style="display: grid; gap: var(--spacing-lg);">
-            <!-- randcoef -->
-            <div class="card" style="padding: var(--spacing-lg); background-color: var(--color-bg-surface); border-radius: var(--radius-lg); box-shadow: var(--shadow-sm); border: 1px solid var(--color-border);">
-              <h2 style="color: var(--color-primary); margin-bottom: 1rem; border-bottom: 2px solid var(--color-accent); display: inline-block; padding-bottom: 0.5rem;">randcoef</h2>
-              <p style="font-size: 1.1rem; color: var(--color-text-muted); margin-bottom: 1rem;">
-                <strong>Description:</strong> Correlated Random Effects Estimation of the Random Coefficients Model
-              </p>
-              <p style="line-height: 1.7; margin-bottom: 1.5rem;">
-                <code>randcoef</code> is a Stata module that estimates the
-                Correlated Random Effects (CRE) model for panel data. It provides an
-                alternative to traditional fixed effects or random effects by
-                allowing for correlation between the unobserved heterogeneity and
-                the observed regressors.
-              </p>
-              <a
-                href="https://ideas.repec.org/c/boc/bocode/s458514.html"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="btn btn-primary"
-              >
-                <i class="fas fa-external-link-alt"></i> View on IDEAS/RePEc
-              </a>
-            </div>
-
-            <!-- wxsum -->
-            <div class="card" style="padding: var(--spacing-lg); background-color: var(--color-bg-surface); border-radius: var(--radius-lg); box-shadow: var(--shadow-sm); border: 1px solid var(--color-border);">
-              <h2 style="color: var(--color-primary); margin-bottom: 1rem; border-bottom: 2px solid var(--color-accent); display: inline-block; padding-bottom: 0.5rem;">wxsum</h2>
-              <p style="font-size: 1.1rem; color: var(--color-text-muted); margin-bottom: 1rem;">
-                <strong>Description:</strong> Summary Statistics with Spatial Weights
-              </p>
-              <p style="line-height: 1.7; margin-bottom: 1.5rem;">
-                <code>wxsum</code> is a Stata module to calculate summary statistics
-                that incorporate spatial weighting matrices. This is particularly
-                useful in spatial econometrics to understand the distribution of
-                variables across geographical space or networks.
-              </p>
-              <a
-                href="https://ideas.repec.org/c/boc/bocode/s458428.html"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="btn btn-primary"
-              >
-                <i class="fas fa-external-link-alt"></i> View on IDEAS/RePEc
-              </a>
-            </div>
+          <!-- wxsum -->
+          <div
+            class="card"
+            style="
+              padding: var(--spacing-lg);
+              background-color: var(--color-bg-surface);
+              border-radius: var(--radius-lg);
+              box-shadow: var(--shadow-sm);
+              border: 1px solid var(--color-border);
+            "
+          >
+            <h2
+              style="
+                color: var(--color-primary);
+                margin-bottom: 1rem;
+                border-bottom: 2px solid var(--color-accent);
+                display: inline-block;
+                padding-bottom: 0.5rem;
+              "
+            >
+              wxsum
+            </h2>
+            <p
+              style="
+                font-size: 1.1rem;
+                color: var(--color-text-muted);
+                margin-bottom: 1rem;
+              "
+            >
+              <strong>Description:</strong> Summary Statistics with Spatial
+              Weights
+            </p>
+            <p style="line-height: 1.7; margin-bottom: 1.5rem">
+              <code>wxsum</code> is a Stata module to calculate summary
+              statistics that incorporate spatial weighting matrices. This is
+              particularly useful in spatial econometrics to understand the
+              distribution of variables across geographical space or networks.
+            </p>
+            <a
+              href="https://ideas.repec.org/c/boc/bocode/s458428.html"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="btn btn-primary"
+            >
+              <i class="fas fa-external-link-alt"></i> View on IDEAS/RePEc
+            </a>
+          </div>
         </div>
-
       </div>
     </main>
 
@@ -146,21 +200,28 @@
             href="https://economics.arizona.edu/person/jeffrey-d-michler"
             title="Departmental Website"
             target="_blank"
+            rel="noopener noreferrer"
             ><i class="fas fa-university"></i
           ></a>
           <a
             href="https://orcid.org/0000-0001-7778-8703"
             title="ORCiD"
             target="_blank"
+            rel="noopener noreferrer"
             ><i class="fab fa-orcid"></i
           ></a>
           <a
             href="https://scholar.google.com/citations?user=your_id_here"
             title="Google Scholar"
             target="_blank"
+            rel="noopener noreferrer"
             ><i class="fas fa-graduation-cap"></i
           ></a>
-          <a href="https://github.com/jdavidm" title="GitHub" target="_blank"
+          <a
+            href="https://github.com/jdavidm"
+            title="GitHub"
+            target="_blank"
+            rel="noopener noreferrer"
             ><i class="fab fa-github"></i
           ></a>
         </div>

--- a/teaching.html
+++ b/teaching.html
@@ -102,6 +102,7 @@
               href="https://aidelab.arizona.edu/"
               class="nav-link"
               target="_blank"
+              rel="noopener noreferrer"
               >AIDE Lab
               <i
                 class="fas fa-external-link-alt"
@@ -236,6 +237,7 @@
                 <a
                   href="https://aidelab.arizona.edu/person/reece-branham"
                   target="_blank"
+                  rel="noopener noreferrer"
                   style="text-decoration: none; color: inherit"
                 >
                   <li class="student-card">
@@ -259,6 +261,7 @@
                 <a
                   href="https://aidelab.arizona.edu/person/chandrakant-agme"
                   target="_blank"
+                  rel="noopener noreferrer"
                   style="text-decoration: none; color: inherit"
                 >
                   <li class="student-card">
@@ -282,6 +285,7 @@
                 <a
                   href="https://aidelab.arizona.edu/person/dewan-al-rafi"
                   target="_blank"
+                  rel="noopener noreferrer"
                   style="text-decoration: none; color: inherit"
                 >
                   <li class="student-card">
@@ -305,6 +309,7 @@
                 <a
                   href="https://aidelab.arizona.edu/person/lorin-rudin-rush"
                   target="_blank"
+                  rel="noopener noreferrer"
                   style="text-decoration: none; color: inherit"
                 >
                   <li class="student-card">
@@ -328,6 +333,7 @@
                 <a
                   href="https://aidelab.arizona.edu/person/ann-furbush"
                   target="_blank"
+                  rel="noopener noreferrer"
                   style="text-decoration: none; color: inherit"
                 >
                   <li class="student-card">
@@ -350,6 +356,7 @@
                 <a
                   href="https://aidelab.arizona.edu/person/laura-mccann"
                   target="_blank"
+                  rel="noopener noreferrer"
                   style="text-decoration: none; color: inherit"
                 >
                   <li class="student-card">
@@ -389,6 +396,7 @@
                 <a
                   href="https://aidelab.arizona.edu/person/ella-anderson"
                   target="_blank"
+                  rel="noopener noreferrer"
                   style="text-decoration: none"
                   ><span class="badge" style="cursor: pointer"
                     >Ella Anderson</span
@@ -397,6 +405,7 @@
                 <a
                   href="https://aidelab.arizona.edu/person/kieran-douglas"
                   target="_blank"
+                  rel="noopener noreferrer"
                   style="text-decoration: none"
                   ><span class="badge" style="cursor: pointer"
                     >Kieran Douglas</span
@@ -405,6 +414,7 @@
                 <a
                   href="https://aidelab.arizona.edu/person/shayan-khan"
                   target="_blank"
+                  rel="noopener noreferrer"
                   style="text-decoration: none"
                   ><span class="badge" style="cursor: pointer"
                     >Shayan Khan</span
@@ -413,6 +423,7 @@
                 <a
                   href="https://aidelab.arizona.edu/person/caroline-klinck"
                   target="_blank"
+                  rel="noopener noreferrer"
                   style="text-decoration: none"
                   ><span class="badge" style="cursor: pointer"
                     >Caroline Klinck</span
@@ -421,6 +432,7 @@
                 <a
                   href="https://aidelab.arizona.edu/person/bryce-smets"
                   target="_blank"
+                  rel="noopener noreferrer"
                   style="text-decoration: none"
                   ><span class="badge" style="cursor: pointer"
                     >Bryce Smets</span
@@ -429,6 +441,7 @@
                 <a
                   href="https://aidelab.arizona.edu/person/jacob-taylor"
                   target="_blank"
+                  rel="noopener noreferrer"
                   style="text-decoration: none"
                   ><span class="badge" style="cursor: pointer"
                     >Jacob Taylor</span
@@ -437,6 +450,7 @@
                 <a
                   href="https://aidelab.arizona.edu/person/tatum-bingham"
                   target="_blank"
+                  rel="noopener noreferrer"
                   style="text-decoration: none"
                   ><span class="badge" style="cursor: pointer"
                     >Tatum Bingham</span
@@ -445,6 +459,7 @@
                 <a
                   href="https://aidelab.arizona.edu/person/reece-branham"
                   target="_blank"
+                  rel="noopener noreferrer"
                   style="text-decoration: none"
                   ><span class="badge" style="cursor: pointer"
                     >Reece Branham</span
@@ -453,6 +468,7 @@
                 <a
                   href="https://aidelab.arizona.edu/person/maxine-cruz"
                   target="_blank"
+                  rel="noopener noreferrer"
                   style="text-decoration: none"
                   ><span class="badge" style="cursor: pointer"
                     >Maxine Cruz</span
@@ -461,6 +477,7 @@
                 <a
                   href="https://aidelab.arizona.edu/person/chi-nguyen"
                   target="_blank"
+                  rel="noopener noreferrer"
                   style="text-decoration: none"
                   ><span class="badge" style="cursor: pointer"
                     >Chi Nguyen</span
@@ -501,21 +518,28 @@
             href="https://economics.arizona.edu/person/jeffrey-d-michler"
             title="Departmental Website"
             target="_blank"
+            rel="noopener noreferrer"
             ><i class="fas fa-university"></i
           ></a>
           <a
             href="https://orcid.org/0000-0001-7778-8703"
             title="ORCiD"
             target="_blank"
+            rel="noopener noreferrer"
             ><i class="fab fa-orcid"></i
           ></a>
           <a
             href="https://scholar.google.com/citations?user=your_id_here"
             title="Google Scholar"
             target="_blank"
+            rel="noopener noreferrer"
             ><i class="fas fa-graduation-cap"></i
           ></a>
-          <a href="https://github.com/jdavidm" title="GitHub" target="_blank"
+          <a
+            href="https://github.com/jdavidm"
+            title="GitHub"
+            target="_blank"
+            rel="noopener noreferrer"
             ><i class="fab fa-github"></i
           ></a>
         </div>


### PR DESCRIPTION
🎯 **What:** Added `rel="noopener noreferrer"` to all anchor tags with `target="_blank"` in the HTML files.

⚠️ **Risk:** Missing this attribute exposes the site to Reverse Tabnabbing. This vulnerability allows newly opened tabs to access the `window.opener` object of the original page, which can be maliciously used to navigate the original page to a phishing or malicious URL.

🛡️ **Solution:** Systematically appended `rel="noopener noreferrer"` to all external links opening in a new tab across the site to sever the link between the new window and the source window, mitigating the security risk while preserving user functionality.

Testing: Evaluated visual layout regression using playwright scripts.

---
*PR created automatically by Jules for task [2590691832671261329](https://jules.google.com/task/2590691832671261329) started by @jdavidm*