### PR TITLE
🧪 Add tests and fix EOF regex in extract_other_pubs.py

### DIFF
--- a/extract_other_pubs.py
+++ b/extract_other_pubs.py
@@ -2,7 +2,7 @@ import re
 
 def parse_tex_section(content, section_name):
     # Find the section and extract items until the next section
-    section_pattern = re.compile(rf'\\section{{\s*{section_name}\s*}}([\s\S]*?)\\section{{', re.IGNORECASE)
+    section_pattern = re.compile(rf'\\section{{\s*{section_name}\s*}}([\s\S]*?)(?:\\section{{|$)', re.IGNORECASE)
     match = section_pattern.search(content)
     if not match:
         return []

--- a/test_extract_other_pubs.py
+++ b/test_extract_other_pubs.py
@@ -1,0 +1,64 @@
+import pytest
+from extract_other_pubs import parse_tex_section
+
+def test_parse_tex_section_happy_path():
+    content = r"""
+\section{Working Papers}
+\begin{itemize}
+\item First paper
+\item Second paper
+with multiple lines
+\end{itemize}
+\section{Next Section}
+"""
+    items = parse_tex_section(content, "Working Papers")
+    assert items == ["First paper", "Second paper with multiple lines"]
+
+def test_parse_tex_section_not_found():
+    content = r"""
+\section{Publications}
+\item Paper
+"""
+    items = parse_tex_section(content, "Working Papers")
+    assert items == []
+
+def test_parse_tex_section_no_items():
+    content = r"""
+\section{Working Papers}
+Some intro text
+\section{Next Section}
+"""
+    items = parse_tex_section(content, "Working Papers")
+    assert items == []
+
+def test_parse_tex_section_case_insensitive():
+    content = r"""
+\section{WORKING PAPERS}
+\item Paper 1
+\section{Next}
+"""
+    items = parse_tex_section(content, "Working Papers")
+    assert items == ["Paper 1"]
+
+def test_parse_tex_section_ignores_begin_end():
+    content = r"""
+\section{Working Papers}
+\begin{itemize}
+\item Paper 1
+\begin{center}
+Some center text
+\end{center}
+\item Paper 2
+\end{itemize}
+\section{Next}
+"""
+    items = parse_tex_section(content, "Working Papers")
+    assert items == ["Paper 1 Some center text", "Paper 2"]
+
+def test_parse_tex_section_eof():
+    content = r"""
+\section{Working Papers}
+\item Paper 1
+"""
+    items = parse_tex_section(content, "Working Papers")
+    assert items == ["Paper 1"]


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
- Missing tests for parse_tex_section in extract_other_pubs.py
- A bug where `parse_tex_section` failed when parsing the last section in the file (due to missing ending section tag).

📊 **Coverage:** What scenarios are now tested
- Happy paths with multiline content
- Missing section
- Missing items within section
- Case-insensitivity in section matching
- `begin`/`end` tag suppression
- File-ending sections (EOF handling)

✨ **Result:** The improvement in test coverage
- parse_tex_section is now comprehensively tested with mocked latex inputs
- The file-ending section bug has been resolved with an updated non-capturing regex group

---
*PR created automatically by Jules for task [11648338152153979320](https://jules.google.com/task/11648338152153979320) started by @jdavidm*