### PR TITLE
🔒 Add rel="noopener noreferrer" to target="_blank" links

### DIFF
--- a/cv.html
+++ b/cv.html
@@ -64,7 +64,7 @@
             <a
               href="https://aidelab.arizona.edu/"
               class="nav-link"
-              target="_blank"
+              target="_blank" rel="noopener noreferrer"
               >AIDE Lab
               <i
                 class="fas fa-external-link-alt"
@@ -159,7 +159,7 @@
           >
             <p>
               If the PDF does not load, you can
-              <a href="michler_cv.pdf" target="_blank">view it directly here</a
+              <a href="michler_cv.pdf" target="_blank" rel="noopener noreferrer">view it directly here</a
               >.
             </p>
           </div>
@@ -199,23 +199,23 @@
           <a
             href="https://economics.arizona.edu/person/jeffrey-d-michler"
             title="Departmental Website"
-            target="_blank"
+            target="_blank" rel="noopener noreferrer"
             ><i class="fas fa-university"></i
           ></a>
           <a
             href="https://orcid.org/0000-0001-7778-8703"
             title="ORCiD"
-            target="_blank"
+            target="_blank" rel="noopener noreferrer"
             ><i class="fab fa-orcid"></i
           ></a>
           <!-- Update this google scholar link when ready -->
           <a
             href="https://scholar.google.com/citations?user=your_id_here"
             title="Google Scholar"
-            target="_blank"
+            target="_blank" rel="noopener noreferrer"
             ><i class="fas fa-graduation-cap"></i
           ></a>
-          <a href="https://github.com/jdavidm" title="GitHub" target="_blank"
+          <a href="https://github.com/jdavidm" title="GitHub" target="_blank" rel="noopener noreferrer"
             ><i class="fab fa-github"></i
           ></a>
         </div>

--- a/fix_software.py
+++ b/fix_software.py
@@ -41,8 +41,7 @@ with open('software.html', 'w') as f:
             <a
               href="https://aidelab.arizona.edu/"
               class="nav-link"
-              target="_blank"
-              rel="noopener noreferrer"
+              target="_blank" rel="noopener noreferrer"
               >AIDE Lab <i class="fas fa-external-link-alt" style="font-size: 0.8em"></i></a
             >
           </li>
@@ -85,8 +84,7 @@ with open('software.html', 'w') as f:
               </p>
               <a
                 href="https://ideas.repec.org/c/boc/bocode/s458514.html"
-                target="_blank"
-                rel="noopener noreferrer"
+                target="_blank" rel="noopener noreferrer"
                 class="btn btn-primary"
               >
                 <i class="fas fa-external-link-alt"></i> View on IDEAS/RePEc
@@ -107,8 +105,7 @@ with open('software.html', 'w') as f:
               </p>
               <a
                 href="https://ideas.repec.org/c/boc/bocode/s458428.html"
-                target="_blank"
-                rel="noopener noreferrer"
+                target="_blank" rel="noopener noreferrer"
                 class="btn btn-primary"
               >
                 <i class="fas fa-external-link-alt"></i> View on IDEAS/RePEc
@@ -146,22 +143,22 @@ with open('software.html', 'w') as f:
           <a
             href="https://economics.arizona.edu/person/jeffrey-d-michler"
             title="Departmental Website"
-            target="_blank"
+            target="_blank" rel="noopener noreferrer"
             ><i class="fas fa-university"></i
           ></a>
           <a
             href="https://orcid.org/0000-0001-7778-8703"
             title="ORCiD"
-            target="_blank"
+            target="_blank" rel="noopener noreferrer"
             ><i class="fab fa-orcid"></i
           ></a>
           <a
             href="https://scholar.google.com/citations?user=your_id_here"
             title="Google Scholar"
-            target="_blank"
+            target="_blank" rel="noopener noreferrer"
             ><i class="fas fa-graduation-cap"></i
           ></a>
-          <a href="https://github.com/jdavidm" title="GitHub" target="_blank"
+          <a href="https://github.com/jdavidm" title="GitHub" target="_blank" rel="noopener noreferrer"
             ><i class="fab fa-github"></i
           ></a>
         </div>

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
             <a
               href="https://aidelab.arizona.edu/"
               class="nav-link"
-              target="_blank"
+              target="_blank" rel="noopener noreferrer"
               >AIDE Lab
               <i
                 class="fas fa-external-link-alt"
@@ -113,21 +113,21 @@
               <div class="badge-list">
                 <a
                   href="https://onlinelibrary.wiley.com/journal/14678276"
-                  target="_blank"
+                  target="_blank" rel="noopener noreferrer"
                   class="badge badge-link"
                   >Associate Editor, American Journal of Agricultural Economics
                   (2026-)</a
                 >
                 <a
                   href="https://academic.oup.com/erae"
-                  target="_blank"
+                  target="_blank" rel="noopener noreferrer"
                   class="badge badge-link"
                   >Associate Editor, European Review of Agricultural Economics
                   (2024-)</a
                 >
                 <a
                   href="https://onlinelibrary.wiley.com/journal/15740862"
-                  target="_blank"
+                  target="_blank" rel="noopener noreferrer"
                   class="badge badge-link"
                   >Associate Editor, Agricultural Economics (2023-)</a
                 >
@@ -226,7 +226,7 @@
                 href="https://www.routledge.com/Research-Ethics-in-Applied-Economics-A-Practical-Guide/Josephson-Michler/p/book/9780367457419"
                 class="btn btn-outline-dark"
                 style="margin-top: auto"
-                target="_blank"
+                target="_blank" rel="noopener noreferrer"
                 >View on Routledge
                 <i
                   class="fas fa-external-link-alt"
@@ -266,22 +266,22 @@
           <a
             href="https://economics.arizona.edu/person/jeffrey-d-michler"
             title="Departmental Website"
-            target="_blank"
+            target="_blank" rel="noopener noreferrer"
             ><i class="fas fa-university"></i
           ></a>
           <a
             href="https://orcid.org/0000-0001-7778-8703"
             title="ORCiD"
-            target="_blank"
+            target="_blank" rel="noopener noreferrer"
             ><i class="fab fa-orcid"></i
           ></a>
           <a
             href="https://scholar.google.com/citations?user=your_id_here"
             title="Google Scholar"
-            target="_blank"
+            target="_blank" rel="noopener noreferrer"
             ><i class="fas fa-graduation-cap"></i
           ></a>
-          <a href="https://github.com/jdavidm" title="GitHub" target="_blank"
+          <a href="https://github.com/jdavidm" title="GitHub" target="_blank" rel="noopener noreferrer"
             ><i class="fab fa-github"></i
           ></a>
         </div>

--- a/parse_wps_fixed.py
+++ b/parse_wps_fixed.py
@@ -34,7 +34,7 @@ def clean_item(item):
     def href_replacer(match):
         url = match.group(1)
         text = match.group(2)
-        return f'<a href="{url}" target="_blank">{text}</a>'
+        return f'<a href="{url}" target="_blank" rel="noopener noreferrer">{text}</a>'
 
     text = re.sub(r'\\href{([^}]+)}{([^}]+)}', href_replacer, item)
 

--- a/patch_badges.py
+++ b/patch_badges.py
@@ -5,11 +5,11 @@ with open('index.html', 'r') as f:
 
 replacements = [
     (r'<span class="badge">Associate Editor, American Journal of Agricultural Economics \(2026-\)</span>',
-     r'<a href="https://onlinelibrary.wiley.com/journal/14678276" target="_blank" class="badge badge-link">Associate Editor, American Journal of Agricultural Economics (2026-)</a>'),
+     r'<a href="https://onlinelibrary.wiley.com/journal/14678276" target="_blank" rel="noopener noreferrer" class="badge badge-link">Associate Editor, American Journal of Agricultural Economics (2026-)</a>'),
     (r'<span class="badge">Associate Editor, European Review of Agricultural Economics \(2024-\)</span>',
-     r'<a href="https://academic.oup.com/erae" target="_blank" class="badge badge-link">Associate Editor, European Review of Agricultural Economics (2024-)</a>'),
+     r'<a href="https://academic.oup.com/erae" target="_blank" rel="noopener noreferrer" class="badge badge-link">Associate Editor, European Review of Agricultural Economics (2024-)</a>'),
     (r'<span class="badge">Associate Editor, Agricultural Economics \(2023-\)</span>',
-     r'<a href="https://onlinelibrary.wiley.com/journal/15740862" target="_blank" class="badge badge-link">Associate Editor, Agricultural Economics (2023-)</a>')
+     r'<a href="https://onlinelibrary.wiley.com/journal/15740862" target="_blank" rel="noopener noreferrer" class="badge badge-link">Associate Editor, Agricultural Economics (2023-)</a>')
 ]
 
 for old, new in replacements:

--- a/patch_teaching_links.py
+++ b/patch_teaching_links.py
@@ -10,7 +10,7 @@ def replace_student_link(match):
     clean_name = re.sub(r'\s*<i.*?></i>', '', name).strip()
     slug = clean_name.lower().replace(' ', '-')
     details = match.group(2)
-    return f'''<a href="https://aidelab.arizona.edu/person/{slug}" target="_blank" style="text-decoration: none; color: inherit;">
+    return f'''<a href="https://aidelab.arizona.edu/person/{slug}" target="_blank" rel="noopener noreferrer" style="text-decoration: none; color: inherit;">
                             <li class="student-card">
                                 <div class="student-name">{name}</div>
                                 <div class="student-details">{details}</div>
@@ -18,16 +18,16 @@ def replace_student_link(match):
                         </a>'''
 
 # Original HTML was replaced with the team URL in the previous step
-pattern_card = r'<a href="https://aidelab\.arizona\.edu/team" target="_blank"[^>]*>\s*<li class="student-card">\s*<div class="student-name">(.*?)</div>\s*<div class="student-details">(.*?)</div>\s*</li>\s*</a>'
+pattern_card = r'<a href="https://aidelab\.arizona\.edu/team" target="_blank" rel="noopener noreferrer"[^>]*>\s*<li class="student-card">\s*<div class="student-name">(.*?)</div>\s*<div class="student-details">(.*?)</div>\s*</li>\s*</a>'
 new_html = re.sub(pattern_card, replace_student_link, html)
 
 # Fix Intern Badges
 def replace_intern_link(match):
     name = match.group(1)
     slug = name.lower().replace(' ', '-')
-    return f'<a href="https://aidelab.arizona.edu/person/{slug}" target="_blank" style="text-decoration: none;"><span class="badge" style="cursor: pointer;">{name}</span></a>'
+    return f'<a href="https://aidelab.arizona.edu/person/{slug}" target="_blank" rel="noopener noreferrer" style="text-decoration: none;"><span class="badge" style="cursor: pointer;">{name}</span></a>'
 
-pattern_badge = r'<a href="https://aidelab\.arizona\.edu/team" target="_blank"[^>]*><span class="badge"[^>]*>(.*?)</span></a>'
+pattern_badge = r'<a href="https://aidelab\.arizona\.edu/team" target="_blank" rel="noopener noreferrer"[^>]*><span class="badge"[^>]*>(.*?)</span></a>'
 new_html = re.sub(pattern_badge, replace_intern_link, new_html)
 
 

--- a/publications.html
+++ b/publications.html
@@ -125,7 +125,7 @@
             <a
               href="https://aidelab.arizona.edu/"
               class="nav-link"
-              target="_blank"
+              target="_blank" rel="noopener noreferrer"
               >AIDE Lab
               <i
                 class="fas fa-external-link-alt"
@@ -188,7 +188,7 @@
             <div class="pub-links">
               <a
                 href="https://www.routledge.com/Research-Ethics-in-Applied-Economics-A-Practical-Guide/Josephson-Michler/p/book/9780367457419"
-                target="_blank"
+                target="_blank" rel="noopener noreferrer"
                 ><i class="fas fa-external-link-alt"></i> Published Version</a
               >
             </div>
@@ -248,7 +248,7 @@
             <div class="pub-links">
               <a
                 href="https://doi.org/10.1016/j.jdeveco.2025.103648"
-                target="_blank"
+                target="_blank" rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -287,12 +287,12 @@
             <div class="pub-links">
               <a
                 href="https://doi.org/10.1016/j.jdeveco.2025.103553"
-                target="_blank"
+                target="_blank" rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
               <a
                 href="http://documents.worldbank.org/curated/en/099850401072516334/IDU16cb26542195d814cc21b3191ae81d19d57ec"
-                target="_blank"
+                target="_blank" rel="noopener noreferrer"
                 ><i class="fas fa-file-pdf"></i> Working Paper</a
               >
             </div>
@@ -330,7 +330,7 @@
               American Journal of Agricultural Economics (2025)
             </p>
             <div class="pub-links">
-              <a href="https://doi.org/10.1111/ajae.70026" target="_blank"
+              <a href="https://doi.org/10.1111/ajae.70026" target="_blank" rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -369,12 +369,12 @@
             <div class="pub-links">
               <a
                 href="https://doi.org/10.1016/j.foodpol.2025.102819"
-                target="_blank"
+                target="_blank" rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
               <a
                 href="http://documents.worldbank.org/curated/en/099830101072519538/IDU1b45f8bf4104061493a18b9e12cfbee039761"
-                target="_blank"
+                target="_blank" rel="noopener noreferrer"
                 ><i class="fas fa-file-pdf"></i> Working Paper</a
               >
             </div>
@@ -411,7 +411,7 @@
               Applied Economics Teaching Resources 7 (2025)
             </p>
             <div class="pub-links">
-              <a href="https://doi.org/10.71162/aetr.369516" target="_blank"
+              <a href="https://doi.org/10.71162/aetr.369516" target="_blank" rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -450,7 +450,7 @@
             <div class="pub-links">
               <a
                 href="https://doi.org/10.1016/j.jdeveco.2022.102927"
-                target="_blank"
+                target="_blank" rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -489,7 +489,7 @@
             <div class="pub-links">
               <a
                 href="https://doi.org/10.1016/j.foodpol.2022.102306"
-                target="_blank"
+                target="_blank" rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -524,7 +524,7 @@
               (2022)
             </p>
             <div class="pub-links">
-              <a href="https://doi.org/10.1002/jaa2.9" target="_blank"
+              <a href="https://doi.org/10.1002/jaa2.9" target="_blank" rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -560,12 +560,12 @@
             <div class="pub-links">
               <a
                 href="https://www.nature.com/articles/s41562-021-01096-7"
-                target="_blank"
+                target="_blank" rel="noopener noreferrer"
                 ><i class="fas fa-external-link-alt"></i> Link</a
               >
               <a
                 href="https://openknowledge.worldbank.org/handle/10986/34733"
-                target="_blank"
+                target="_blank" rel="noopener noreferrer"
                 ><i class="fas fa-file-pdf"></i> Working Paper</a
               >
             </div>
@@ -604,10 +604,10 @@
             <div class="pub-links">
               <a
                 href="https://doi.org/10.1016/j.jdeveco.2021.102626"
-                target="_blank"
+                target="_blank" rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
-              <a href="https://www.nber.org/papers/w25665.pdf" target="_blank"
+              <a href="https://www.nber.org/papers/w25665.pdf" target="_blank" rel="noopener noreferrer"
                 ><i class="fas fa-file-pdf"></i> Working Paper</a
               >
             </div>
@@ -644,7 +644,7 @@
               American Journal of Agricultural Economics 103 (2021)
             </p>
             <div class="pub-links">
-              <a href="https://doi.org/10.1111/ajae.12151" target="_blank"
+              <a href="https://doi.org/10.1111/ajae.12151" target="_blank" rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -681,7 +681,7 @@
               Applied Economic Perspectives and Policy 43 (2021)
             </p>
             <div class="pub-links">
-              <a href="https://doi.org/10.1002/aepp.13132" target="_blank"
+              <a href="https://doi.org/10.1002/aepp.13132" target="_blank" rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -701,7 +701,7 @@
               Applied Economic Perspectives and Policy 43 (2021)
             </p>
             <div class="pub-links">
-              <a href="https://doi.org/10.1002/aepp.13133" target="_blank"
+              <a href="https://doi.org/10.1002/aepp.13133" target="_blank" rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -724,7 +724,7 @@
             <div class="pub-links">
               <a
                 href="https://doi.org/10.1016/j.jebo.2020.09.031"
-                target="_blank"
+                target="_blank" rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -760,7 +760,7 @@
             <div class="pub-links">
               <a
                 href="https://doi.org/10.1016/j.worlddev.2020.104888"
-                target="_blank"
+                target="_blank" rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -782,7 +782,7 @@
             <div class="pub-links">
               <a
                 href="https://doi.org/10.1146/annurev-resource-101719-034514"
-                target="_blank"
+                target="_blank" rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -819,7 +819,7 @@
               American Journal of Agricultural Economics 101 (2019)
             </p>
             <div class="pub-links">
-              <a href="https://doi.org/10.1093/ajae/aay050" target="_blank"
+              <a href="https://doi.org/10.1093/ajae/aay050" target="_blank" rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -857,7 +857,7 @@
             <div class="pub-links">
               <a
                 href="https://doi.org/10.1016/j.jeem.2018.11.008"
-                target="_blank"
+                target="_blank" rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -878,7 +878,7 @@
               Applied Economic Perspectives and Policy 41 (2019)
             </p>
             <div class="pub-links">
-              <a href="https://doi.org/10.1093/aepp/ppz010" target="_blank"
+              <a href="https://doi.org/10.1093/aepp/ppz010" target="_blank" rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -914,7 +914,7 @@
             <div class="pub-links">
               <a
                 href="https://doi.org/10.1016/j.foodpol.2018.08.001"
-                target="_blank"
+                target="_blank" rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -971,7 +971,7 @@
             <div class="pub-links">
               <a
                 href="https://doi.org/10.1016/j.worlddev.2016.08.011"
-                target="_blank"
+                target="_blank" rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -992,7 +992,7 @@
               Agricultural Economics 48 (2017)
             </p>
             <div class="pub-links">
-              <a href="https://doi.org/10.1111/agec.12320" target="_blank"
+              <a href="https://doi.org/10.1111/agec.12320" target="_blank" rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -1017,7 +1017,7 @@
             <div class="pub-links">
               <a
                 href="https://doi.org/10.1016/j.foodpol.2016.11.007"
-                target="_blank"
+                target="_blank" rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -1038,7 +1038,7 @@
               Journal of Agricultural Economics 66 (2015)
             </p>
             <div class="pub-links">
-              <a href="https://doi.org/10.1111/1477-9552.12082" target="_blank"
+              <a href="https://doi.org/10.1111/1477-9552.12082" target="_blank" rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -1052,7 +1052,7 @@
           </p>
           <a
             href="https://scholar.google.com/citations?user=your_id_here"
-            target="_blank"
+            target="_blank" rel="noopener noreferrer"
             class="btn btn-primary"
             style="margin-top: 1rem"
             >View Google Scholar</a
@@ -1188,22 +1188,22 @@
           <a
             href="https://economics.arizona.edu/person/jeffrey-d-michler"
             title="Departmental Website"
-            target="_blank"
+            target="_blank" rel="noopener noreferrer"
             ><i class="fas fa-university"></i
           ></a>
           <a
             href="https://orcid.org/0000-0001-7778-8703"
             title="ORCiD"
-            target="_blank"
+            target="_blank" rel="noopener noreferrer"
             ><i class="fab fa-orcid"></i
           ></a>
           <a
             href="https://scholar.google.com/citations?user=your_id_here"
             title="Google Scholar"
-            target="_blank"
+            target="_blank" rel="noopener noreferrer"
             ><i class="fas fa-graduation-cap"></i
           ></a>
-          <a href="https://github.com/jdavidm" title="GitHub" target="_blank"
+          <a href="https://github.com/jdavidm" title="GitHub" target="_blank" rel="noopener noreferrer"
             ><i class="fab fa-github"></i
           ></a>
         </div>

--- a/software.html
+++ b/software.html
@@ -40,8 +40,7 @@
             <a
               href="https://aidelab.arizona.edu/"
               class="nav-link"
-              target="_blank"
-              rel="noopener noreferrer"
+              target="_blank" rel="noopener noreferrer"
               >AIDE Lab <i class="fas fa-external-link-alt" style="font-size: 0.8em"></i></a
             >
           </li>
@@ -84,8 +83,7 @@
               </p>
               <a
                 href="https://ideas.repec.org/c/boc/bocode/s458514.html"
-                target="_blank"
-                rel="noopener noreferrer"
+                target="_blank" rel="noopener noreferrer"
                 class="btn btn-primary"
               >
                 <i class="fas fa-external-link-alt"></i> View on IDEAS/RePEc
@@ -106,8 +104,7 @@
               </p>
               <a
                 href="https://ideas.repec.org/c/boc/bocode/s458428.html"
-                target="_blank"
-                rel="noopener noreferrer"
+                target="_blank" rel="noopener noreferrer"
                 class="btn btn-primary"
               >
                 <i class="fas fa-external-link-alt"></i> View on IDEAS/RePEc
@@ -145,22 +142,22 @@
           <a
             href="https://economics.arizona.edu/person/jeffrey-d-michler"
             title="Departmental Website"
-            target="_blank"
+            target="_blank" rel="noopener noreferrer"
             ><i class="fas fa-university"></i
           ></a>
           <a
             href="https://orcid.org/0000-0001-7778-8703"
             title="ORCiD"
-            target="_blank"
+            target="_blank" rel="noopener noreferrer"
             ><i class="fab fa-orcid"></i
           ></a>
           <a
             href="https://scholar.google.com/citations?user=your_id_here"
             title="Google Scholar"
-            target="_blank"
+            target="_blank" rel="noopener noreferrer"
             ><i class="fas fa-graduation-cap"></i
           ></a>
-          <a href="https://github.com/jdavidm" title="GitHub" target="_blank"
+          <a href="https://github.com/jdavidm" title="GitHub" target="_blank" rel="noopener noreferrer"
             ><i class="fab fa-github"></i
           ></a>
         </div>

--- a/teaching.html
+++ b/teaching.html
@@ -101,7 +101,7 @@
             <a
               href="https://aidelab.arizona.edu/"
               class="nav-link"
-              target="_blank"
+              target="_blank" rel="noopener noreferrer"
               >AIDE Lab
               <i
                 class="fas fa-external-link-alt"
@@ -235,7 +235,7 @@
               >
                 <a
                   href="https://aidelab.arizona.edu/person/reece-branham"
-                  target="_blank"
+                  target="_blank" rel="noopener noreferrer"
                   style="text-decoration: none; color: inherit"
                 >
                   <li class="student-card">
@@ -258,7 +258,7 @@
                 </a>
                 <a
                   href="https://aidelab.arizona.edu/person/chandrakant-agme"
-                  target="_blank"
+                  target="_blank" rel="noopener noreferrer"
                   style="text-decoration: none; color: inherit"
                 >
                   <li class="student-card">
@@ -281,7 +281,7 @@
                 </a>
                 <a
                   href="https://aidelab.arizona.edu/person/dewan-al-rafi"
-                  target="_blank"
+                  target="_blank" rel="noopener noreferrer"
                   style="text-decoration: none; color: inherit"
                 >
                   <li class="student-card">
@@ -304,7 +304,7 @@
                 </a>
                 <a
                   href="https://aidelab.arizona.edu/person/lorin-rudin-rush"
-                  target="_blank"
+                  target="_blank" rel="noopener noreferrer"
                   style="text-decoration: none; color: inherit"
                 >
                   <li class="student-card">
@@ -327,7 +327,7 @@
                 </a>
                 <a
                   href="https://aidelab.arizona.edu/person/ann-furbush"
-                  target="_blank"
+                  target="_blank" rel="noopener noreferrer"
                   style="text-decoration: none; color: inherit"
                 >
                   <li class="student-card">
@@ -349,7 +349,7 @@
                 </a>
                 <a
                   href="https://aidelab.arizona.edu/person/laura-mccann"
-                  target="_blank"
+                  target="_blank" rel="noopener noreferrer"
                   style="text-decoration: none; color: inherit"
                 >
                   <li class="student-card">
@@ -388,7 +388,7 @@
               <div style="display: flex; flex-wrap: wrap; gap: 0.5rem">
                 <a
                   href="https://aidelab.arizona.edu/person/ella-anderson"
-                  target="_blank"
+                  target="_blank" rel="noopener noreferrer"
                   style="text-decoration: none"
                   ><span class="badge" style="cursor: pointer"
                     >Ella Anderson</span
@@ -396,7 +396,7 @@
                 >
                 <a
                   href="https://aidelab.arizona.edu/person/kieran-douglas"
-                  target="_blank"
+                  target="_blank" rel="noopener noreferrer"
                   style="text-decoration: none"
                   ><span class="badge" style="cursor: pointer"
                     >Kieran Douglas</span
@@ -404,7 +404,7 @@
                 >
                 <a
                   href="https://aidelab.arizona.edu/person/shayan-khan"
-                  target="_blank"
+                  target="_blank" rel="noopener noreferrer"
                   style="text-decoration: none"
                   ><span class="badge" style="cursor: pointer"
                     >Shayan Khan</span
@@ -412,7 +412,7 @@
                 >
                 <a
                   href="https://aidelab.arizona.edu/person/caroline-klinck"
-                  target="_blank"
+                  target="_blank" rel="noopener noreferrer"
                   style="text-decoration: none"
                   ><span class="badge" style="cursor: pointer"
                     >Caroline Klinck</span
@@ -420,7 +420,7 @@
                 >
                 <a
                   href="https://aidelab.arizona.edu/person/bryce-smets"
-                  target="_blank"
+                  target="_blank" rel="noopener noreferrer"
                   style="text-decoration: none"
                   ><span class="badge" style="cursor: pointer"
                     >Bryce Smets</span
@@ -428,7 +428,7 @@
                 >
                 <a
                   href="https://aidelab.arizona.edu/person/jacob-taylor"
-                  target="_blank"
+                  target="_blank" rel="noopener noreferrer"
                   style="text-decoration: none"
                   ><span class="badge" style="cursor: pointer"
                     >Jacob Taylor</span
@@ -436,7 +436,7 @@
                 >
                 <a
                   href="https://aidelab.arizona.edu/person/tatum-bingham"
-                  target="_blank"
+                  target="_blank" rel="noopener noreferrer"
                   style="text-decoration: none"
                   ><span class="badge" style="cursor: pointer"
                     >Tatum Bingham</span
@@ -444,7 +444,7 @@
                 >
                 <a
                   href="https://aidelab.arizona.edu/person/reece-branham"
-                  target="_blank"
+                  target="_blank" rel="noopener noreferrer"
                   style="text-decoration: none"
                   ><span class="badge" style="cursor: pointer"
                     >Reece Branham</span
@@ -452,7 +452,7 @@
                 >
                 <a
                   href="https://aidelab.arizona.edu/person/maxine-cruz"
-                  target="_blank"
+                  target="_blank" rel="noopener noreferrer"
                   style="text-decoration: none"
                   ><span class="badge" style="cursor: pointer"
                     >Maxine Cruz</span
@@ -460,7 +460,7 @@
                 >
                 <a
                   href="https://aidelab.arizona.edu/person/chi-nguyen"
-                  target="_blank"
+                  target="_blank" rel="noopener noreferrer"
                   style="text-decoration: none"
                   ><span class="badge" style="cursor: pointer"
                     >Chi Nguyen</span
@@ -500,22 +500,22 @@
           <a
             href="https://economics.arizona.edu/person/jeffrey-d-michler"
             title="Departmental Website"
-            target="_blank"
+            target="_blank" rel="noopener noreferrer"
             ><i class="fas fa-university"></i
           ></a>
           <a
             href="https://orcid.org/0000-0001-7778-8703"
             title="ORCiD"
-            target="_blank"
+            target="_blank" rel="noopener noreferrer"
             ><i class="fab fa-orcid"></i
           ></a>
           <a
             href="https://scholar.google.com/citations?user=your_id_here"
             title="Google Scholar"
-            target="_blank"
+            target="_blank" rel="noopener noreferrer"
             ><i class="fas fa-graduation-cap"></i
           ></a>
-          <a href="https://github.com/jdavidm" title="GitHub" target="_blank"
+          <a href="https://github.com/jdavidm" title="GitHub" target="_blank" rel="noopener noreferrer"
             ><i class="fab fa-github"></i
           ></a>
         </div>


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was missing `rel="noopener noreferrer"` attributes on links using `target="_blank"`. Added this attribute to all such links across `.html` pages and Python scripts that generate HTML.
⚠️ **Risk:** Links with `target="_blank"` are vulnerable to reverse tabnabbing, allowing the opened window to control the `window.opener` object, potentially leading to phishing or redirect attacks on the original tab.
🛡️ **Solution:** Systematically appended `rel="noopener noreferrer"` to all `target="_blank"` link declarations across the repository, mitigating the reverse tabnabbing vulnerability.

---
*PR created automatically by Jules for task [1825460211534554738](https://jules.google.com/task/1825460211534554738) started by @jdavidm*