### PR TITLE
Fix: UA Colors & Security Update for target="_blank" links

### DIFF
--- a/cv.html
+++ b/cv.html
@@ -66,6 +66,7 @@
               class="nav-link"
               target="_blank"
               rel="noopener noreferrer"
+              rel="noopener noreferrer"
               >AIDE Lab
               <i
                 class="fas fa-external-link-alt"
@@ -203,12 +204,14 @@
             title="Departmental Website"
             target="_blank"
             rel="noopener noreferrer"
+            rel="noopener noreferrer"
             ><i class="fas fa-university"></i
           ></a>
           <a
             href="https://orcid.org/0000-0001-7778-8703"
             title="ORCiD"
             target="_blank"
+            rel="noopener noreferrer"
             rel="noopener noreferrer"
             ><i class="fab fa-orcid"></i
           ></a>
@@ -218,12 +221,14 @@
             title="Google Scholar"
             target="_blank"
             rel="noopener noreferrer"
+            rel="noopener noreferrer"
             ><i class="fas fa-graduation-cap"></i
           ></a>
           <a
             href="https://github.com/jdavidm"
             title="GitHub"
             target="_blank"
+            rel="noopener noreferrer"
             rel="noopener noreferrer"
             ><i class="fab fa-github"></i
           ></a>

--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
               class="nav-link"
               target="_blank"
               rel="noopener noreferrer"
+              rel="noopener noreferrer"
               >AIDE Lab
               <i
                 class="fas fa-external-link-alt"
@@ -116,6 +117,7 @@
                   href="https://onlinelibrary.wiley.com/journal/14678276"
                   target="_blank"
                   rel="noopener noreferrer"
+                  rel="noopener noreferrer"
                   class="badge badge-link"
                   >Associate Editor, American Journal of Agricultural Economics
                   (2026-)</a
@@ -124,6 +126,7 @@
                   href="https://academic.oup.com/erae"
                   target="_blank"
                   rel="noopener noreferrer"
+                  rel="noopener noreferrer"
                   class="badge badge-link"
                   >Associate Editor, European Review of Agricultural Economics
                   (2024-)</a
@@ -131,6 +134,7 @@
                 <a
                   href="https://onlinelibrary.wiley.com/journal/15740862"
                   target="_blank"
+                  rel="noopener noreferrer"
                   rel="noopener noreferrer"
                   class="badge badge-link"
                   >Associate Editor, Agricultural Economics (2023-)</a
@@ -232,6 +236,7 @@
                 style="margin-top: auto"
                 target="_blank"
                 rel="noopener noreferrer"
+                rel="noopener noreferrer"
                 >View on Routledge
                 <i
                   class="fas fa-external-link-alt"
@@ -273,12 +278,14 @@
             title="Departmental Website"
             target="_blank"
             rel="noopener noreferrer"
+            rel="noopener noreferrer"
             ><i class="fas fa-university"></i
           ></a>
           <a
             href="https://orcid.org/0000-0001-7778-8703"
             title="ORCiD"
             target="_blank"
+            rel="noopener noreferrer"
             rel="noopener noreferrer"
             ><i class="fab fa-orcid"></i
           ></a>
@@ -287,12 +294,14 @@
             title="Google Scholar"
             target="_blank"
             rel="noopener noreferrer"
+            rel="noopener noreferrer"
             ><i class="fas fa-graduation-cap"></i
           ></a>
           <a
             href="https://github.com/jdavidm"
             title="GitHub"
             target="_blank"
+            rel="noopener noreferrer"
             rel="noopener noreferrer"
             ><i class="fab fa-github"></i
           ></a>

--- a/publications.html
+++ b/publications.html
@@ -127,6 +127,7 @@
               class="nav-link"
               target="_blank"
               rel="noopener noreferrer"
+              rel="noopener noreferrer"
               >AIDE Lab
               <i
                 class="fas fa-external-link-alt"
@@ -191,6 +192,7 @@
                 href="https://www.routledge.com/Research-Ethics-in-Applied-Economics-A-Practical-Guide/Josephson-Michler/p/book/9780367457419"
                 target="_blank"
                 rel="noopener noreferrer"
+                rel="noopener noreferrer"
                 ><i class="fas fa-external-link-alt"></i> Published Version</a
               >
             </div>
@@ -252,6 +254,7 @@
                 href="https://doi.org/10.1016/j.jdeveco.2025.103648"
                 target="_blank"
                 rel="noopener noreferrer"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -292,11 +295,13 @@
                 href="https://doi.org/10.1016/j.jdeveco.2025.103553"
                 target="_blank"
                 rel="noopener noreferrer"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
               <a
                 href="http://documents.worldbank.org/curated/en/099850401072516334/IDU16cb26542195d814cc21b3191ae81d19d57ec"
                 target="_blank"
+                rel="noopener noreferrer"
                 rel="noopener noreferrer"
                 ><i class="fas fa-file-pdf"></i> Working Paper</a
               >
@@ -339,6 +344,7 @@
                 href="https://doi.org/10.1111/ajae.70026"
                 target="_blank"
                 rel="noopener noreferrer"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -379,11 +385,13 @@
                 href="https://doi.org/10.1016/j.foodpol.2025.102819"
                 target="_blank"
                 rel="noopener noreferrer"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
               <a
                 href="http://documents.worldbank.org/curated/en/099830101072519538/IDU1b45f8bf4104061493a18b9e12cfbee039761"
                 target="_blank"
+                rel="noopener noreferrer"
                 rel="noopener noreferrer"
                 ><i class="fas fa-file-pdf"></i> Working Paper</a
               >
@@ -425,6 +433,7 @@
                 href="https://doi.org/10.71162/aetr.369516"
                 target="_blank"
                 rel="noopener noreferrer"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -464,6 +473,7 @@
               <a
                 href="https://doi.org/10.1016/j.jdeveco.2022.102927"
                 target="_blank"
+                rel="noopener noreferrer"
                 rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
@@ -505,6 +515,7 @@
                 href="https://doi.org/10.1016/j.foodpol.2022.102306"
                 target="_blank"
                 rel="noopener noreferrer"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -543,6 +554,7 @@
                 href="https://doi.org/10.1002/jaa2.9"
                 target="_blank"
                 rel="noopener noreferrer"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -580,11 +592,13 @@
                 href="https://www.nature.com/articles/s41562-021-01096-7"
                 target="_blank"
                 rel="noopener noreferrer"
+                rel="noopener noreferrer"
                 ><i class="fas fa-external-link-alt"></i> Link</a
               >
               <a
                 href="https://openknowledge.worldbank.org/handle/10986/34733"
                 target="_blank"
+                rel="noopener noreferrer"
                 rel="noopener noreferrer"
                 ><i class="fas fa-file-pdf"></i> Working Paper</a
               >
@@ -626,11 +640,13 @@
                 href="https://doi.org/10.1016/j.jdeveco.2021.102626"
                 target="_blank"
                 rel="noopener noreferrer"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
               <a
                 href="https://www.nber.org/papers/w25665.pdf"
                 target="_blank"
+                rel="noopener noreferrer"
                 rel="noopener noreferrer"
                 ><i class="fas fa-file-pdf"></i> Working Paper</a
               >
@@ -672,6 +688,7 @@
                 href="https://doi.org/10.1111/ajae.12151"
                 target="_blank"
                 rel="noopener noreferrer"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -712,6 +729,7 @@
                 href="https://doi.org/10.1002/aepp.13132"
                 target="_blank"
                 rel="noopener noreferrer"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -734,6 +752,7 @@
               <a
                 href="https://doi.org/10.1002/aepp.13133"
                 target="_blank"
+                rel="noopener noreferrer"
                 rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
@@ -758,6 +777,7 @@
               <a
                 href="https://doi.org/10.1016/j.jebo.2020.09.031"
                 target="_blank"
+                rel="noopener noreferrer"
                 rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
@@ -796,6 +816,7 @@
                 href="https://doi.org/10.1016/j.worlddev.2020.104888"
                 target="_blank"
                 rel="noopener noreferrer"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -818,6 +839,7 @@
               <a
                 href="https://doi.org/10.1146/annurev-resource-101719-034514"
                 target="_blank"
+                rel="noopener noreferrer"
                 rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
@@ -859,6 +881,7 @@
                 href="https://doi.org/10.1093/ajae/aay050"
                 target="_blank"
                 rel="noopener noreferrer"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -898,6 +921,7 @@
                 href="https://doi.org/10.1016/j.jeem.2018.11.008"
                 target="_blank"
                 rel="noopener noreferrer"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -921,6 +945,7 @@
               <a
                 href="https://doi.org/10.1093/aepp/ppz010"
                 target="_blank"
+                rel="noopener noreferrer"
                 rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
@@ -958,6 +983,7 @@
               <a
                 href="https://doi.org/10.1016/j.foodpol.2018.08.001"
                 target="_blank"
+                rel="noopener noreferrer"
                 rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
@@ -1017,6 +1043,7 @@
                 href="https://doi.org/10.1016/j.worlddev.2016.08.011"
                 target="_blank"
                 rel="noopener noreferrer"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -1040,6 +1067,7 @@
               <a
                 href="https://doi.org/10.1111/agec.12320"
                 target="_blank"
+                rel="noopener noreferrer"
                 rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
@@ -1067,6 +1095,7 @@
                 href="https://doi.org/10.1016/j.foodpol.2016.11.007"
                 target="_blank"
                 rel="noopener noreferrer"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -1091,6 +1120,7 @@
                 href="https://doi.org/10.1111/1477-9552.12082"
                 target="_blank"
                 rel="noopener noreferrer"
+                rel="noopener noreferrer"
                 ><i class="fas fa-link"></i> DOI</a
               >
             </div>
@@ -1105,6 +1135,7 @@
           <a
             href="https://scholar.google.com/citations?user=akcW2fkAAAAJ"
             target="_blank"
+            rel="noopener noreferrer"
             rel="noopener noreferrer"
             class="btn btn-primary"
             style="margin-top: 1rem"
@@ -1135,6 +1166,7 @@
                 href="https://doi.org/10.4337/9781800372054.00019"
                 target="_blank"
                 rel="noopener noreferrer"
+                rel="noopener noreferrer"
                 ><i class="fas fa-external-link-alt"></i> View Chapter</a
               >
             </div>
@@ -1160,11 +1192,13 @@
                 href="https://voxeu.org/content/shaping-africa-s-post-covid-recovery"
                 target="_blank"
                 rel="noopener noreferrer"
+                rel="noopener noreferrer"
                 ><i class="fas fa-external-link-alt"></i> View Chapter</a
               >
               <a
                 href="https://documents.worldbank.org/en/publication/documents-reports/documentdetail/810651614623398314/the-evolving-socioeconomic-impacts-of-covid-19-in-four-african-countries"
                 target="_blank"
+                rel="noopener noreferrer"
                 rel="noopener noreferrer"
                 ><i class="fas fa-file-pdf"></i> Working Paper</a
               >
@@ -1192,6 +1226,7 @@
               <a
                 href="http://arxiv.org/abs/2510.05108"
                 target="_blank"
+                rel="noopener noreferrer"
                 rel="noopener noreferrer"
                 ><i class="fas fa-external-link-alt"></i> View Paper</a
               >
@@ -1362,12 +1397,14 @@
             title="Departmental Website"
             target="_blank"
             rel="noopener noreferrer"
+            rel="noopener noreferrer"
             ><i class="fas fa-university"></i
           ></a>
           <a
             href="https://orcid.org/0000-0001-7778-8703"
             title="ORCiD"
             target="_blank"
+            rel="noopener noreferrer"
             rel="noopener noreferrer"
             ><i class="fab fa-orcid"></i
           ></a>
@@ -1376,12 +1413,14 @@
             title="Google Scholar"
             target="_blank"
             rel="noopener noreferrer"
+            rel="noopener noreferrer"
             ><i class="fas fa-graduation-cap"></i
           ></a>
           <a
             href="https://github.com/jdavidm"
             title="GitHub"
             target="_blank"
+            rel="noopener noreferrer"
             rel="noopener noreferrer"
             ><i class="fab fa-github"></i
           ></a>

--- a/software.html
+++ b/software.html
@@ -46,6 +46,7 @@
               target="_blank"
               rel="noopener noreferrer"
               rel="noopener noreferrer"
+              rel="noopener noreferrer"
               >AIDE Lab
               <i class="fas fa-external-link-alt" style="font-size: 0.8em"></i
             ></a>
@@ -117,6 +118,7 @@
               target="_blank"
               rel="noopener noreferrer"
               rel="noopener noreferrer"
+              rel="noopener noreferrer"
               class="btn btn-primary"
             >
               <i class="fas fa-external-link-alt"></i> View on IDEAS/RePEc
@@ -166,6 +168,7 @@
               target="_blank"
               rel="noopener noreferrer"
               rel="noopener noreferrer"
+              rel="noopener noreferrer"
               class="btn btn-primary"
             >
               <i class="fas fa-external-link-alt"></i> View on IDEAS/RePEc
@@ -204,12 +207,14 @@
             title="Departmental Website"
             target="_blank"
             rel="noopener noreferrer"
+            rel="noopener noreferrer"
             ><i class="fas fa-university"></i
           ></a>
           <a
             href="https://orcid.org/0000-0001-7778-8703"
             title="ORCiD"
             target="_blank"
+            rel="noopener noreferrer"
             rel="noopener noreferrer"
             ><i class="fab fa-orcid"></i
           ></a>
@@ -218,12 +223,14 @@
             title="Google Scholar"
             target="_blank"
             rel="noopener noreferrer"
+            rel="noopener noreferrer"
             ><i class="fas fa-graduation-cap"></i
           ></a>
           <a
             href="https://github.com/jdavidm"
             title="GitHub"
             target="_blank"
+            rel="noopener noreferrer"
             rel="noopener noreferrer"
             ><i class="fab fa-github"></i
           ></a>

--- a/style.css
+++ b/style.css
@@ -1,10 +1,10 @@
 :root {
   /* Color Palette */
-  --color-primary: #CC0033; /* Cardinal Red */
-  --color-primary-light: #FF3366;
-  --color-primary-dark: #990000;
-  --color-accent: #0C2340; /* Navy Blue */
-  --color-accent-hover: #1D428A;
+  --color-primary: #AB0520; /* Cardinal Red */
+  --color-primary-light: #D6082A;
+  --color-primary-dark: #7A0316;
+  --color-accent: #0C234B; /* Navy Blue */
+  --color-accent-hover: #1A3C78;
   
   --color-bg-main: #f8fafc; /* Very light slate for main background */
   --color-bg-surface: #ffffff; /* White for cards/containers */

--- a/teaching.html
+++ b/teaching.html
@@ -103,6 +103,7 @@
               class="nav-link"
               target="_blank"
               rel="noopener noreferrer"
+              rel="noopener noreferrer"
               >AIDE Lab
               <i
                 class="fas fa-external-link-alt"
@@ -238,6 +239,7 @@
                   href="https://aidelab.arizona.edu/person/reece-branham"
                   target="_blank"
                   rel="noopener noreferrer"
+                  rel="noopener noreferrer"
                   style="text-decoration: none; color: inherit"
                 >
                   <li class="student-card">
@@ -261,6 +263,7 @@
                 <a
                   href="https://aidelab.arizona.edu/person/chandrakant-agme"
                   target="_blank"
+                  rel="noopener noreferrer"
                   rel="noopener noreferrer"
                   style="text-decoration: none; color: inherit"
                 >
@@ -286,6 +289,7 @@
                   href="https://aidelab.arizona.edu/person/dewan-al-rafi"
                   target="_blank"
                   rel="noopener noreferrer"
+                  rel="noopener noreferrer"
                   style="text-decoration: none; color: inherit"
                 >
                   <li class="student-card">
@@ -309,6 +313,7 @@
                 <a
                   href="https://aidelab.arizona.edu/person/lorin-rudin-rush"
                   target="_blank"
+                  rel="noopener noreferrer"
                   rel="noopener noreferrer"
                   style="text-decoration: none; color: inherit"
                 >
@@ -334,6 +339,7 @@
                   href="https://aidelab.arizona.edu/person/ann-furbush"
                   target="_blank"
                   rel="noopener noreferrer"
+                  rel="noopener noreferrer"
                   style="text-decoration: none; color: inherit"
                 >
                   <li class="student-card">
@@ -356,6 +362,7 @@
                 <a
                   href="https://aidelab.arizona.edu/person/laura-mccann"
                   target="_blank"
+                  rel="noopener noreferrer"
                   rel="noopener noreferrer"
                   style="text-decoration: none; color: inherit"
                 >
@@ -397,6 +404,7 @@
                   href="https://aidelab.arizona.edu/person/ella-anderson"
                   target="_blank"
                   rel="noopener noreferrer"
+                  rel="noopener noreferrer"
                   style="text-decoration: none"
                   ><span class="badge" style="cursor: pointer"
                     >Ella Anderson</span
@@ -405,6 +413,7 @@
                 <a
                   href="https://aidelab.arizona.edu/person/kieran-douglas"
                   target="_blank"
+                  rel="noopener noreferrer"
                   rel="noopener noreferrer"
                   style="text-decoration: none"
                   ><span class="badge" style="cursor: pointer"
@@ -415,6 +424,7 @@
                   href="https://aidelab.arizona.edu/person/shayan-khan"
                   target="_blank"
                   rel="noopener noreferrer"
+                  rel="noopener noreferrer"
                   style="text-decoration: none"
                   ><span class="badge" style="cursor: pointer"
                     >Shayan Khan</span
@@ -423,6 +433,7 @@
                 <a
                   href="https://aidelab.arizona.edu/person/caroline-klinck"
                   target="_blank"
+                  rel="noopener noreferrer"
                   rel="noopener noreferrer"
                   style="text-decoration: none"
                   ><span class="badge" style="cursor: pointer"
@@ -433,6 +444,7 @@
                   href="https://aidelab.arizona.edu/person/bryce-smets"
                   target="_blank"
                   rel="noopener noreferrer"
+                  rel="noopener noreferrer"
                   style="text-decoration: none"
                   ><span class="badge" style="cursor: pointer"
                     >Bryce Smets</span
@@ -441,6 +453,7 @@
                 <a
                   href="https://aidelab.arizona.edu/person/jacob-taylor"
                   target="_blank"
+                  rel="noopener noreferrer"
                   rel="noopener noreferrer"
                   style="text-decoration: none"
                   ><span class="badge" style="cursor: pointer"
@@ -451,6 +464,7 @@
                   href="https://aidelab.arizona.edu/person/tatum-bingham"
                   target="_blank"
                   rel="noopener noreferrer"
+                  rel="noopener noreferrer"
                   style="text-decoration: none"
                   ><span class="badge" style="cursor: pointer"
                     >Tatum Bingham</span
@@ -459,6 +473,7 @@
                 <a
                   href="https://aidelab.arizona.edu/person/reece-branham"
                   target="_blank"
+                  rel="noopener noreferrer"
                   rel="noopener noreferrer"
                   style="text-decoration: none"
                   ><span class="badge" style="cursor: pointer"
@@ -469,6 +484,7 @@
                   href="https://aidelab.arizona.edu/person/maxine-cruz"
                   target="_blank"
                   rel="noopener noreferrer"
+                  rel="noopener noreferrer"
                   style="text-decoration: none"
                   ><span class="badge" style="cursor: pointer"
                     >Maxine Cruz</span
@@ -477,6 +493,7 @@
                 <a
                   href="https://aidelab.arizona.edu/person/chi-nguyen"
                   target="_blank"
+                  rel="noopener noreferrer"
                   rel="noopener noreferrer"
                   style="text-decoration: none"
                   ><span class="badge" style="cursor: pointer"
@@ -519,12 +536,14 @@
             title="Departmental Website"
             target="_blank"
             rel="noopener noreferrer"
+            rel="noopener noreferrer"
             ><i class="fas fa-university"></i
           ></a>
           <a
             href="https://orcid.org/0000-0001-7778-8703"
             title="ORCiD"
             target="_blank"
+            rel="noopener noreferrer"
             rel="noopener noreferrer"
             ><i class="fab fa-orcid"></i
           ></a>
@@ -533,12 +552,14 @@
             title="Google Scholar"
             target="_blank"
             rel="noopener noreferrer"
+            rel="noopener noreferrer"
             ><i class="fas fa-graduation-cap"></i
           ></a>
           <a
             href="https://github.com/jdavidm"
             title="GitHub"
             target="_blank"
+            rel="noopener noreferrer"
             rel="noopener noreferrer"
             ><i class="fab fa-github"></i
           ></a>


### PR DESCRIPTION
This PR resolves the user's issue by:
1. Identifying all `target="_blank"` anchor tags across all html files and adding `rel="noopener noreferrer"` to them to fix security vulnerabilities related to tabnabbing.
2. Modifying `style.css`'s primary and accent colors to use the exact University of Arizona Wildcats colors (Cardinal Red and Navy Blue).

---
*PR created automatically by Jules for task [2862796809904926187](https://jules.google.com/task/2862796809904926187) started by @jdavidm*