### PR TITLE
style: lighten hero banners across all pages

### DIFF
--- a/cv.html
+++ b/cv.html
@@ -35,7 +35,6 @@
         z-index: 10;
       }
       .page-header {
-        background-color: var(--color-accent);
         color: white;
         padding: var(--spacing-xl) 0 var(--spacing-lg) 0;
         text-align: center;

--- a/style.css
+++ b/style.css
@@ -208,7 +208,7 @@ a:hover {
   height: 100%;
   object-fit: cover;
   z-index: 0;
-  opacity: 0.4; /* Darken background for text readability */
+  opacity: 0.6; /* Darken background for text readability */
 
 }
 


### PR DESCRIPTION
Addresses user request to lighten the shading on banner images and unify the hero banner color across all pages by using the base color from the home page.

- Removed \`background-color: var(--color-accent);\` from \`.page-header\` in \`cv.html\`.
- Adjusted \`opacity\` of \`.hero-bg\` from 0.4 to 0.6 in \`style.css\`.

---
*PR created automatically by Jules for task [5552761072435073642](https://jules.google.com/task/5552761072435073642) started by @jdavidm*