### PR TITLE
Fix publication links and reposition bibliographic info

### DIFF
--- a/agriculture-process-development-micro-perspective.html
+++ b/agriculture-process-development-micro-perspective.html
@@ -112,6 +112,8 @@
           <h1>
             Agriculture in the Process of Development: A Micro-Perspective
           </h1>
+          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Michler, J.D. (2020). "Agriculture in the Process of Development: A
+            Micro-Perspective." World Development 129: 104888.</p>
         </div>
       </div>
     </header>
@@ -120,10 +122,7 @@
     <main class="section">
       <div class="container" style="max-width: 800px; margin: 0 auto">
         <div class="animate-on-scroll">
-          <div class="paper-biblio">
-            Michler, J.D. (2020). "Agriculture in the Process of Development: A
-            Micro-Perspective." World Development 129: 104888.
-          </div>
+
 
           <h2 class="section-title">Abstract</h2>
           <div class="paper-abstract">

--- a/beasts-field-ethics-agricultural-and-applied-economics.html
+++ b/beasts-field-ethics-agricultural-and-applied-economics.html
@@ -112,6 +112,8 @@
           <h1>
             Beasts of the Field? Ethics in Agricultural and Applied Economics
           </h1>
+          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Josephson, A., and Michler, J.D. (2018). "Beasts of the Field?
+            Ethics in Agricultural and Applied Economics." Food Policy 79: 1-11.</p>
         </div>
       </div>
     </header>
@@ -120,10 +122,7 @@
     <main class="section">
       <div class="container" style="max-width: 800px; margin: 0 auto">
         <div class="animate-on-scroll">
-          <div class="paper-biblio">
-            Josephson, A., and Michler, J.D. (2018). "Beasts of the Field?
-            Ethics in Agricultural and Applied Economics." Food Policy 79: 1-11.
-          </div>
+
 
           <h2 class="section-title">Abstract</h2>
           <div class="paper-abstract">

--- a/conservation-agriculture-and-climate-resilience.html
+++ b/conservation-agriculture-and-climate-resilience.html
@@ -109,6 +109,9 @@
       <div class="container relative z-10">
         <div class="hero-content">
           <h1>Conservation Agriculture and Climate Resilience</h1>
+          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Michler, J.D., Baylis, K., Arends-Kuenning, M., and Mazvimavi, K.
+            (2019). "Conservation Agriculture and Climate Resilience." Journal
+            of Environmental Economics and Management 93: 148-69.</p>
         </div>
       </div>
     </header>
@@ -117,11 +120,7 @@
     <main class="section">
       <div class="container" style="max-width: 800px; margin: 0 auto">
         <div class="animate-on-scroll">
-          <div class="paper-biblio">
-            Michler, J.D., Baylis, K., Arends-Kuenning, M., and Mazvimavi, K.
-            (2019). "Conservation Agriculture and Climate Resilience." Journal
-            of Environmental Economics and Management 93: 148-69.
-          </div>
+
 
           <h2 class="section-title">Abstract</h2>
           <div class="paper-abstract">

--- a/contract-farming-and-rural-transformation.html
+++ b/contract-farming-and-rural-transformation.html
@@ -109,6 +109,9 @@
       <div class="container relative z-10">
         <div class="hero-content">
           <h1>Contract Farming and Rural Transformation</h1>
+          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Arouna, A., J.D. Michler, and J.C. Lokossou (2021). "Contract
+            farming and rural transformation: Evidence from a field experiment
+            in Benin." Journal of Development Economics 151: 102626.</p>
         </div>
       </div>
     </header>
@@ -117,11 +120,7 @@
     <main class="section">
       <div class="container" style="max-width: 800px; margin: 0 auto">
         <div class="animate-on-scroll">
-          <div class="paper-biblio">
-            Arouna, A., J.D. Michler, and J.C. Lokossou (2021). "Contract
-            farming and rural transformation: Evidence from a field experiment
-            in Benin." Journal of Development Economics 151: 102626.
-          </div>
+
 
           <h2 class="section-title">Abstract</h2>
           <div class="paper-abstract">

--- a/coping-or-hoping.html
+++ b/coping-or-hoping.html
@@ -104,6 +104,9 @@
       <div class="container relative z-10">
         <div class="hero-content">
           <h1>Coping or Hoping</h1>
+          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Furbush, A., Josephson, A., Kilic, T., and Michler, J.D. (2025).
+            "Coping or Hoping? Livelihood Diversification and Food Insecurity in
+            the COVID-19 Pandemic." Food Policy 131: 102819.</p>
         </div>
       </div>
     </header>
@@ -112,11 +115,7 @@
     <main class="section">
       <div class="container" style="max-width: 800px; margin: 0 auto">
         <div class="animate-on-scroll">
-          <div class="paper-biblio">
-            Furbush, A., Josephson, A., Kilic, T., and Michler, J.D. (2025).
-            "Coping or Hoping? Livelihood Diversification and Food Insecurity in
-            the COVID-19 Pandemic." Food Policy 131: 102819.
-          </div>
+
 
           <h2 class="section-title">Abstract</h2>
           <div class="paper-abstract">

--- a/cost-climate-action.html
+++ b/cost-climate-action.html
@@ -100,6 +100,7 @@
       <div class="container relative z-10">
         <div class="hero-content">
           <h1>Cost of Climate Action</h1>
+          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);"></p>
         </div>
       </div>
     </header>
@@ -108,7 +109,7 @@
     <main class="section">
       <div class="container" style="max-width: 800px; margin: 0 auto">
         <div class="animate-on-scroll">
-          <div class="paper-biblio"></div>
+
 
           <h2 class="section-title">Abstract</h2>
           <div class="paper-abstract">

--- a/economics-climate-adaptation.html
+++ b/economics-climate-adaptation.html
@@ -100,6 +100,7 @@
       <div class="container relative z-10">
         <div class="hero-content">
           <h1>The Economics of Climate Adaptation</h1>
+          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);"></p>
         </div>
       </div>
     </header>
@@ -108,7 +109,7 @@
     <main class="section">
       <div class="container" style="max-width: 800px; margin: 0 auto">
         <div class="animate-on-scroll">
-          <div class="paper-biblio"></div>
+
 
           <h2 class="section-title">Abstract</h2>
           <div class="paper-abstract">

--- a/evolving-impact-covid-19-four-african-countries.html
+++ b/evolving-impact-covid-19-four-african-countries.html
@@ -106,6 +106,10 @@
       <div class="container relative z-10">
         <div class="hero-content">
           <h1>The Evolving Impact of COVID-19 in Four African Countries</h1>
+          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Furbush, A., Josephson, A., Kilic, T., and Michler, J.D. (2021).
+            "The Evolving Impact of COVID-19 in Four African Countries," in R.
+            Arezki, S. Djankov, and U. Panizza, eds., Shaping Africa’s
+            Post-Covid Recovery. London: CEPR Press.</p>
         </div>
       </div>
     </header>
@@ -114,12 +118,7 @@
     <main class="section">
       <div class="container" style="max-width: 800px; margin: 0 auto">
         <div class="animate-on-scroll">
-          <div class="paper-biblio">
-            Furbush, A., Josephson, A., Kilic, T., and Michler, J.D. (2021).
-            "The Evolving Impact of COVID-19 in Four African Countries," in R.
-            Arezki, S. Djankov, and U. Panizza, eds., Shaping Africa’s
-            Post-Covid Recovery. London: CEPR Press.
-          </div>
+
 
           <h2 class="section-title">Abstract</h2>
           <div class="paper-abstract">

--- a/expanding-undergraduate-research-experience.html
+++ b/expanding-undergraduate-research-experience.html
@@ -109,6 +109,10 @@
       <div class="container relative z-10">
         <div class="hero-content">
           <h1>Expanding Undergraduate Research Experience</h1>
+          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Athnos, A., Josephson, A., Michler, J.D., and Rudin-Rush, L. (2024).
+            "Expanding Undergraduate Research Experience: Opportunities,
+            Challenges, and Lessons for the Future." Applied Economics Teaching
+            Resources, forthcoming.</p>
         </div>
       </div>
     </header>
@@ -117,12 +121,7 @@
     <main class="section">
       <div class="container" style="max-width: 800px; margin: 0 auto">
         <div class="animate-on-scroll">
-          <div class="paper-biblio">
-            Athnos, A., Josephson, A., Michler, J.D., and Rudin-Rush, L. (2024).
-            "Expanding Undergraduate Research Experience: Opportunities,
-            Challenges, and Lessons for the Future." Applied Economics Teaching
-            Resources, forthcoming.
-          </div>
+
 
           <h2 class="section-title">Abstract</h2>
           <div class="paper-abstract">

--- a/exploring-crop-yield-dynamics-across-sub-saharan-africa-six-country-study.html
+++ b/exploring-crop-yield-dynamics-across-sub-saharan-africa-six-country-study.html
@@ -109,6 +109,7 @@
             Exploring Crop Yield Dynamics Across Sub-Saharan Africa: A Six
             Country Study
           </h1>
+          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);"></p>
         </div>
       </div>
     </header>
@@ -117,7 +118,7 @@
     <main class="section">
       <div class="container" style="max-width: 800px; margin: 0 auto">
         <div class="animate-on-scroll">
-          <div class="paper-biblio"></div>
+
 
           <h2 class="section-title">Abstract</h2>
           <div class="paper-abstract">

--- a/farmer-family-firms-and-missing-markets.html
+++ b/farmer-family-firms-and-missing-markets.html
@@ -103,6 +103,8 @@
       <div class="container relative z-10">
         <div class="hero-content">
           <h1>Farmer Family Firms and Missing Markets</h1>
+          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Kee-Tui, E., Josephson, A., and Michler, J.D. "Farmer Family Firms
+            and Missing Markets: Evidence from the Philippines, 1970-2016."</p>
         </div>
       </div>
     </header>
@@ -111,10 +113,7 @@
     <main class="section">
       <div class="container" style="max-width: 800px; margin: 0 auto">
         <div class="animate-on-scroll">
-          <div class="paper-biblio">
-            Kee-Tui, E., Josephson, A., and Michler, J.D. "Farmer Family Firms
-            and Missing Markets: Evidence from the Philippines, 1970-2016."
-          </div>
+
 
           <h2 class="section-title">Abstract</h2>
           <div class="paper-abstract">

--- a/food-insecurity-during-first-year-covid-19-pandemic-four-african-countries.html
+++ b/food-insecurity-during-first-year-covid-19-pandemic-four-african-countries.html
@@ -113,6 +113,9 @@
             Food Insecurity During the First Year of the COVID-19 Pandemic in
             Four African Countries
           </h1>
+          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Rudin-Rush, L., J.D. Michler, A. Josephson, and J.R. Bloem. (2022).
+            "Food Insecurity During the First Year of the COVID-19 Pandemic in
+            Four African Countries." Food Policy 111: 102306.</p>
         </div>
       </div>
     </header>
@@ -121,11 +124,7 @@
     <main class="section">
       <div class="container" style="max-width: 800px; margin: 0 auto">
         <div class="animate-on-scroll">
-          <div class="paper-biblio">
-            Rudin-Rush, L., J.D. Michler, A. Josephson, and J.R. Bloem. (2022).
-            "Food Insecurity During the First Year of the COVID-19 Pandemic in
-            Four African Countries." Food Policy 111: 102306.
-          </div>
+
 
           <h2 class="section-title">Abstract</h2>
           <div class="paper-abstract">

--- a/food-without-fire.html
+++ b/food-without-fire.html
@@ -104,6 +104,10 @@
       <div class="container relative z-10">
         <div class="hero-content">
           <h1>Food Without Fire</h1>
+          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">McCann, L., Michler, J.D., Mwangala, M., Olurotimi, O., and Estrada
+            Carmona, N. (2025). "Food Without Fire: Environmental and
+            Nutritional Impacts from a Solar Stove Field Experiment." American
+            Journal of Agricultural Economics.</p>
         </div>
       </div>
     </header>
@@ -112,12 +116,7 @@
     <main class="section">
       <div class="container" style="max-width: 800px; margin: 0 auto">
         <div class="animate-on-scroll">
-          <div class="paper-biblio">
-            McCann, L., Michler, J.D., Mwangala, M., Olurotimi, O., and Estrada
-            Carmona, N. (2025). "Food Without Fire: Environmental and
-            Nutritional Impacts from a Solar Stove Field Experiment." American
-            Journal of Agricultural Economics.
-          </div>
+
 
           <h2 class="section-title">Abstract</h2>
           <div class="paper-abstract">

--- a/impact-evaluations-data-poor-settings.html
+++ b/impact-evaluations-data-poor-settings.html
@@ -107,6 +107,10 @@
       <div class="container relative z-10">
         <div class="hero-content">
           <h1>Impact Evaluations in Data Poor Settings</h1>
+          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Michler, J.D., Al Rafi, D.A., Giezendanner, J., Josephson, A., Pede,
+            V.O., and Tellman, E. (2026). "Impact Evaluations in Data Poor
+            Settings: The Case of Stress-Tolerant Rice Varieties in Bangladesh."
+            Journal of Development Economics: 103648.</p>
         </div>
       </div>
     </header>
@@ -115,12 +119,7 @@
     <main class="section">
       <div class="container" style="max-width: 800px; margin: 0 auto">
         <div class="animate-on-scroll">
-          <div class="paper-biblio">
-            Michler, J.D., Al Rafi, D.A., Giezendanner, J., Josephson, A., Pede,
-            V.O., and Tellman, E. (2026). "Impact Evaluations in Data Poor
-            Settings: The Case of Stress-Tolerant Rice Varieties in Bangladesh."
-            Journal of Development Economics: 103648.
-          </div>
+
 
           <h2 class="section-title">Abstract</h2>
           <div class="paper-abstract">

--- a/intra-household-inequality-food-expenditures-and-diet-quality-philippines.html
+++ b/intra-household-inequality-food-expenditures-and-diet-quality-philippines.html
@@ -109,6 +109,7 @@
             Intra-household inequality in food expenditures and diet quality in
             the Philippines
           </h1>
+          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);"></p>
         </div>
       </div>
     </header>
@@ -117,7 +118,7 @@
     <main class="section">
       <div class="container" style="max-width: 800px; margin: 0 auto">
         <div class="animate-on-scroll">
-          <div class="paper-biblio"></div>
+
 
           <h2 class="section-title">Abstract</h2>
           <div class="paper-abstract">

--- a/intra-household-management-joint-resources.html
+++ b/intra-household-management-joint-resources.html
@@ -105,6 +105,7 @@
       <div class="container relative z-10">
         <div class="hero-content">
           <h1>Intra-Household Management of Joint Resources</h1>
+          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);"></p>
         </div>
       </div>
     </header>
@@ -113,7 +114,7 @@
     <main class="section">
       <div class="container" style="max-width: 800px; margin: 0 auto">
         <div class="animate-on-scroll">
-          <div class="paper-biblio"></div>
+
 
           <h2 class="section-title">Abstract</h2>
           <div class="paper-abstract">

--- a/mismeasure-weather.html
+++ b/mismeasure-weather.html
@@ -104,6 +104,10 @@
       <div class="container relative z-10">
         <div class="hero-content">
           <h1>The Mismeasure of Weather</h1>
+          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Josephson, A., Michler, J.D., Kilic, T., and Murray, S. (2026). "The
+            Mismeasure of Weather: Using Earth Observation Data for Estimation
+            of Socioeconomic Outcomes." Journal of Development Economics 178:
+            103553.</p>
         </div>
       </div>
     </header>
@@ -112,12 +116,7 @@
     <main class="section">
       <div class="container" style="max-width: 800px; margin: 0 auto">
         <div class="animate-on-scroll">
-          <div class="paper-biblio">
-            Josephson, A., Michler, J.D., Kilic, T., and Murray, S. (2026). "The
-            Mismeasure of Weather: Using Earth Observation Data for Estimation
-            of Socioeconomic Outcomes." Journal of Development Economics 178:
-            103553.
-          </div>
+
 
           <h2 class="section-title">Abstract</h2>
           <div class="paper-abstract">

--- a/money-matters-role-yields-and-profits-agricultural-technology-adoption.html
+++ b/money-matters-role-yields-and-profits-agricultural-technology-adoption.html
@@ -113,6 +113,10 @@
             Money Matters: The Role of Yields and Profits in Agricultural
             Technology Adoption
           </h1>
+          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Michler, J.D., Tjernström, E., Verkaart, S. and Mausch, K. (2019).
+            "Money Matters: The Role of Yields and Profits in Agricultural
+            Technology Adoption." American Journal of Agricultural Economics 101
+            (3): 710-31.</p>
         </div>
       </div>
     </header>
@@ -121,12 +125,7 @@
     <main class="section">
       <div class="container" style="max-width: 800px; margin: 0 auto">
         <div class="animate-on-scroll">
-          <div class="paper-biblio">
-            Michler, J.D., Tjernström, E., Verkaart, S. and Mausch, K. (2019).
-            "Money Matters: The Role of Yields and Profits in Agricultural
-            Technology Adoption." American Journal of Agricultural Economics 101
-            (3): 710-31.
-          </div>
+
 
           <h2 class="section-title">Abstract</h2>
           <div class="paper-abstract">

--- a/one-size-fits-all.html
+++ b/one-size-fits-all.html
@@ -104,6 +104,10 @@
       <div class="container relative z-10">
         <div class="hero-content">
           <h1>One Size Fits All</h1>
+          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Arouna, A., J.D. Michler, W.G. Yergo, and K. Saito. 2021. “One Size
+            Fits All? Experimental Evidence on the Digital Delivery of
+            Personalized Extension Advice in Nigeria.” American Journal of
+            Agricultural Economics 103 (2): 596-619.</p>
         </div>
       </div>
     </header>
@@ -112,12 +116,7 @@
     <main class="section">
       <div class="container" style="max-width: 800px; margin: 0 auto">
         <div class="animate-on-scroll">
-          <div class="paper-biblio">
-            Arouna, A., J.D. Michler, W.G. Yergo, and K. Saito. 2021. “One Size
-            Fits All? Experimental Evidence on the Digital Delivery of
-            Personalized Extension Advice in Nigeria.” American Journal of
-            Agricultural Economics 103 (2): 596-619.
-          </div>
+
 
           <h2 class="section-title">Abstract</h2>
           <div class="paper-abstract">

--- a/privacy-protection-measurement-error-and-integration-remote-sensing-and-socioeconomic-survey-data.html
+++ b/privacy-protection-measurement-error-and-integration-remote-sensing-and-socioeconomic-survey-data.html
@@ -113,6 +113,10 @@
             Privacy Protection, Measurement Error, and the Integration of Remote
             Sensing and Socioeconomic Survey Data
           </h1>
+          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Michler, J.D., Josephson, A., Kilic, T., and Murray, S. (2022).
+            "Privacy Protection, Measurement Error, and the Integration of
+            Remote Sensing and Socioeconomic Survey Data." Journal of
+            Development Economics 158: 102927.</p>
         </div>
       </div>
     </header>
@@ -121,12 +125,7 @@
     <main class="section">
       <div class="container" style="max-width: 800px; margin: 0 auto">
         <div class="animate-on-scroll">
-          <div class="paper-biblio">
-            Michler, J.D., Josephson, A., Kilic, T., and Murray, S. (2022).
-            "Privacy Protection, Measurement Error, and the Integration of
-            Remote Sensing and Socioeconomic Survey Data." Journal of
-            Development Economics 158: 102927.
-          </div>
+
 
           <h2 class="section-title">Abstract</h2>
           <div class="paper-abstract">

--- a/publications.html
+++ b/publications.html
@@ -184,9 +184,7 @@
               color: inherit;
               display: flex;
               flex-direction: column;
-            "
-            target="_blank"
-          >
+            " >
             <span
               class="card-tag"
               style="background-color: var(--color-accent); color: white"
@@ -208,9 +206,7 @@
               color: inherit;
               display: flex;
               flex-direction: column;
-            "
-            target="_blank"
-          >
+            " >
             <span
               class="card-tag"
               style="background-color: var(--color-primary-light); color: white"
@@ -691,9 +687,7 @@
               color: inherit;
               display: flex;
               flex-direction: column;
-            "
-            target="_blank"
-          >
+            " >
             <span
               class="card-tag"
               style="background-color: var(--color-primary-light); color: white"
@@ -718,9 +712,7 @@
               color: inherit;
               display: flex;
               flex-direction: column;
-            "
-            target="_blank"
-          >
+            " >
             <span
               class="card-tag"
               style="background-color: var(--color-primary-light); color: white"
@@ -780,9 +772,7 @@
               color: inherit;
               display: flex;
               flex-direction: column;
-            "
-            target="_blank"
-          >
+            " >
             <span
               class="card-tag"
               style="background-color: var(--color-primary-light); color: white"
@@ -881,9 +871,7 @@
               color: inherit;
               display: flex;
               flex-direction: column;
-            "
-            target="_blank"
-          >
+            " >
             <span
               class="card-tag"
               style="background-color: var(--color-primary-light); color: white"
@@ -943,9 +931,7 @@
               color: inherit;
               display: flex;
               flex-direction: column;
-            "
-            target="_blank"
-          >
+            " >
             <span
               class="card-tag"
               style="background-color: var(--color-primary-light); color: white"
@@ -1009,9 +995,7 @@
               color: inherit;
               display: flex;
               flex-direction: column;
-            "
-            target="_blank"
-          >
+            " >
             <span
               class="card-tag"
               style="background-color: var(--color-primary-light); color: white"
@@ -1036,9 +1020,7 @@
               color: inherit;
               display: flex;
               flex-direction: column;
-            "
-            target="_blank"
-          >
+            " >
             <span
               class="card-tag"
               style="background-color: var(--color-primary-light); color: white"
@@ -1065,9 +1047,7 @@
               color: inherit;
               display: flex;
               flex-direction: column;
-            "
-            target="_blank"
-          >
+            " >
             <span
               class="card-tag"
               style="background-color: var(--color-primary-light); color: white"
@@ -1110,9 +1090,7 @@
               color: inherit;
               display: flex;
               flex-direction: column;
-            "
-            target="_blank"
-          >
+            " >
             <span
               class="card-tag"
               style="background-color: var(--color-accent); color: white"
@@ -1138,9 +1116,7 @@
               color: inherit;
               display: flex;
               flex-direction: column;
-            "
-            target="_blank"
-          >
+            " >
             <span
               class="card-tag"
               style="background-color: var(--color-accent); color: white"
@@ -1171,9 +1147,7 @@
               color: inherit;
               display: flex;
               flex-direction: column;
-            "
-            target="_blank"
-          >
+            " >
             <span
               class="card-tag"
               style="background-color: var(--color-secondary); color: white"
@@ -1197,9 +1171,7 @@
               color: inherit;
               display: flex;
               flex-direction: column;
-            "
-            target="_blank"
-          >
+            " >
             <span
               class="card-tag"
               style="background-color: var(--color-secondary); color: white"
@@ -1224,9 +1196,7 @@
               color: inherit;
               display: flex;
               flex-direction: column;
-            "
-            target="_blank"
-          >
+            " >
             <span
               class="card-tag"
               style="background-color: var(--color-secondary); color: white"
@@ -1250,9 +1220,7 @@
               color: inherit;
               display: flex;
               flex-direction: column;
-            "
-            target="_blank"
-          >
+            " >
             <span
               class="card-tag"
               style="background-color: var(--color-secondary); color: white"
@@ -1276,9 +1244,7 @@
               color: inherit;
               display: flex;
               flex-direction: column;
-            "
-            target="_blank"
-          >
+            " >
             <span
               class="card-tag"
               style="background-color: var(--color-secondary); color: white"
@@ -1302,9 +1268,7 @@
               color: inherit;
               display: flex;
               flex-direction: column;
-            "
-            target="_blank"
-          >
+            " >
             <span
               class="card-tag"
               style="background-color: var(--color-secondary); color: white"
@@ -1328,9 +1292,7 @@
               color: inherit;
               display: flex;
               flex-direction: column;
-            "
-            target="_blank"
-          >
+            " >
             <span
               class="card-tag"
               style="background-color: var(--color-secondary); color: white"
@@ -1351,9 +1313,7 @@
               color: inherit;
               display: flex;
               flex-direction: column;
-            "
-            target="_blank"
-          >
+            " >
             <span
               class="card-tag"
               style="background-color: var(--color-secondary); color: white"
@@ -1377,9 +1337,7 @@
               color: inherit;
               display: flex;
               flex-direction: column;
-            "
-            target="_blank"
-          >
+            " >
             <span
               class="card-tag"
               style="background-color: var(--color-secondary); color: white"
@@ -1400,9 +1358,7 @@
               color: inherit;
               display: flex;
               flex-direction: column;
-            "
-            target="_blank"
-          >
+            " >
             <span
               class="card-tag"
               style="background-color: var(--color-secondary); color: white"
@@ -1424,9 +1380,7 @@
               color: inherit;
               display: flex;
               flex-direction: column;
-            "
-            target="_blank"
-          >
+            " >
             <span
               class="card-tag"
               style="background-color: var(--color-secondary); color: white"

--- a/recent-developments-inference-practicalities-applied-economics.html
+++ b/recent-developments-inference-practicalities-applied-economics.html
@@ -109,6 +109,10 @@
             Recent developments in inference: practicalities for applied
             economics
           </h1>
+          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Michler, J.D. and A. Josephson. (2022). "Recent Developments in
+            Inference: Practicalities for the Applied Economist." In J. Roosen
+            and J.E. Hobbs, eds., A Modern Guide to Food Economics. Cheltenham:
+            Edward Elgar Publishing.</p>
         </div>
       </div>
     </header>
@@ -117,12 +121,7 @@
     <main class="section">
       <div class="container" style="max-width: 800px; margin: 0 auto">
         <div class="animate-on-scroll">
-          <div class="paper-biblio">
-            Michler, J.D. and A. Josephson. (2022). "Recent Developments in
-            Inference: Practicalities for the Applied Economist." In J. Roosen
-            and J.E. Hobbs, eds., A Modern Guide to Food Economics. Cheltenham:
-            Edward Elgar Publishing.
-          </div>
+
 
           <h2 class="section-title">Abstract</h2>
           <div class="paper-abstract">

--- a/research-ethics-beyond-irb-selection-bias-and-direction-innovation-applied-economics.html
+++ b/research-ethics-beyond-irb-selection-bias-and-direction-innovation-applied-economics.html
@@ -113,6 +113,10 @@
             Research ethics beyond the IRB: Selection bias and the direction of
             innovation in applied economics
           </h1>
+          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Michler, J.D., Masters, W.A., and Josephson, A. (2021). "Research
+            Ethics Beyond the IRB: Selection Bias and the Direction of
+            Innovation in Applied Economics." Applied Economic Perspectives and
+            Policy 43 (4): 1352-65.</p>
         </div>
       </div>
     </header>
@@ -121,12 +125,7 @@
     <main class="section">
       <div class="container" style="max-width: 800px; margin: 0 auto">
         <div class="animate-on-scroll">
-          <div class="paper-biblio">
-            Michler, J.D., Masters, W.A., and Josephson, A. (2021). "Research
-            Ethics Beyond the IRB: Selection Bias and the Direction of
-            Innovation in Applied Economics." Applied Economic Perspectives and
-            Policy 43 (4): 1352-65.
-          </div>
+
 
           <h2 class="section-title">Abstract</h2>
           <div class="paper-abstract">

--- a/risk-and-rainfall-specification-sensitivity-estimating-smallholder-risk-preferences.html
+++ b/risk-and-rainfall-specification-sensitivity-estimating-smallholder-risk-preferences.html
@@ -109,6 +109,7 @@
             Risk and Rainfall: Specification Sensitivity in Estimating
             Smallholder Risk Preferences
           </h1>
+          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);"></p>
         </div>
       </div>
     </header>
@@ -117,7 +118,7 @@
     <main class="section">
       <div class="container" style="max-width: 800px; margin: 0 auto">
         <div class="animate-on-scroll">
-          <div class="paper-biblio"></div>
+
 
           <h2 class="section-title">Abstract</h2>
           <div class="paper-abstract">

--- a/socioeconomic-impacts-covid-19-low-income-countries.html
+++ b/socioeconomic-impacts-covid-19-low-income-countries.html
@@ -110,6 +110,9 @@
       <div class="container relative z-10">
         <div class="hero-content">
           <h1>Socioeconomic Impacts of COVID-19 in Low-Income Countries</h1>
+          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Josephson, A., T. Kilic, and J.D. Michler. (2021). Socioeconomic
+            Impacts of COVID-19 in Low-Income Countries." Nature Human Behaviour
+            5: 557-65.</p>
         </div>
       </div>
     </header>
@@ -118,11 +121,7 @@
     <main class="section">
       <div class="container" style="max-width: 800px; margin: 0 auto">
         <div class="animate-on-scroll">
-          <div class="paper-biblio">
-            Josephson, A., T. Kilic, and J.D. Michler. (2021). Socioeconomic
-            Impacts of COVID-19 in Low-Income Countries." Nature Human Behaviour
-            5: 557-65.
-          </div>
+
 
           <h2 class="section-title">Abstract</h2>
           <div class="paper-abstract">

--- a/specialize-or-diversify-agricultural-diversity-and-poverty-dynamics-ethiopia.html
+++ b/specialize-or-diversify-agricultural-diversity-and-poverty-dynamics-ethiopia.html
@@ -113,6 +113,9 @@
             To Specialize or Diversify: Agricultural Diversity and Poverty
             Dynamics in Ethiopia
           </h1>
+          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Michler, J.D. and Josephson, A. (2017).  "To Specialize or
+            Diversify: Agricultural Diversity and Poverty Dynamics in Ethiopia."
+            World Development 89: 214-26.</p>
         </div>
       </div>
     </header>
@@ -121,11 +124,7 @@
     <main class="section">
       <div class="container" style="max-width: 800px; margin: 0 auto">
         <div class="animate-on-scroll">
-          <div class="paper-biblio">
-            Michler, J.D. and Josephson, A. (2017).  "To Specialize or
-            Diversify: Agricultural Diversity and Poverty Dynamics in Ethiopia."
-            World Development 89: 214-26.
-          </div>
+
 
           <h2 class="section-title">Abstract</h2>
           <div class="paper-abstract">

--- a/ulysses-pact-or-ulysses-raft-using-pre-analysis-plans-experimental-and-nonexperimental-research.html
+++ b/ulysses-pact-or-ulysses-raft-using-pre-analysis-plans-experimental-and-nonexperimental-research.html
@@ -109,6 +109,10 @@
             Ulysses' Pact or Ulysses' Raft: Using Pre-Analysis Plans in
             Experimental and Nonexperimental Research
           </h1>
+          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Janzen, S. and Michler, J.D. (2021). "Ulysses' Pact or Ulysses'
+            Raft: Using Pre-Analysis Plans in Experimental and Nonexperimental
+            Research." Applied Economic Perspectives and Policy 43 (4):
+            1286-1304.</p>
         </div>
       </div>
     </header>
@@ -117,12 +121,7 @@
     <main class="section">
       <div class="container" style="max-width: 800px; margin: 0 auto">
         <div class="animate-on-scroll">
-          <div class="paper-biblio">
-            Janzen, S. and Michler, J.D. (2021). "Ulysses' Pact or Ulysses'
-            Raft: Using Pre-Analysis Plans in Experimental and Nonexperimental
-            Research." Applied Economic Perspectives and Policy 43 (4):
-            1286-1304.
-          </div>
+
 
           <h2 class="section-title">Abstract</h2>
           <div class="paper-abstract">

--- a/variable-selection-economic-applications-remotely-sensed-weather-data.html
+++ b/variable-selection-economic-applications-remotely-sensed-weather-data.html
@@ -109,6 +109,7 @@
             Variable Selection in Economic Applications of Remotely Sensed
             Weather Data
           </h1>
+          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);"></p>
         </div>
       </div>
     </header>
@@ -117,7 +118,7 @@
     <main class="section">
       <div class="container" style="max-width: 800px; margin: 0 auto">
         <div class="animate-on-scroll">
-          <div class="paper-biblio"></div>
+
 
           <h2 class="section-title">Abstract</h2>
           <div class="paper-abstract">

--- a/what-do-you-mean-informed-consent-ethics-economic-development-research.html
+++ b/what-do-you-mean-informed-consent-ethics-economic-development-research.html
@@ -109,6 +109,7 @@
             What Do you Mean by “Informed Consent”? Ethics in Economic
             Development Research
           </h1>
+          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);"></p>
         </div>
       </div>
     </header>
@@ -117,7 +118,7 @@
     <main class="section">
       <div class="container" style="max-width: 800px; margin: 0 auto">
         <div class="animate-on-scroll">
-          <div class="paper-biblio"></div>
+
 
           <h2 class="section-title">Abstract</h2>
           <div class="paper-abstract">


### PR DESCRIPTION
1. Removed `target="_blank"` from publication card links in `publications.html` so they open in the same tab.
2. Moved the bibliographic information (`.paper-biblio`) up into the `.hero-content` section underneath the title for each individual publication HTML file.
3. Formatted modified files with Prettier.

---
*PR created automatically by Jules for task [16158519392853009280](https://jules.google.com/task/16158519392853009280) started by @jdavidm*