### PR TITLE
Fix citation layout across publication pages

### DIFF
--- a/agriculture-process-development-micro-perspective.html
+++ b/agriculture-process-development-micro-perspective.html
@@ -107,12 +107,9 @@
         alt="Background"
         class="hero-bg"
       />
-      <div class="container relative z-10">
+      <div class="container relative z-10" style="max-width: 800px; margin: 0 auto;">
         <div class="hero-content">
-          <h1>
-            Agriculture in the Process of Development: A Micro-Perspective
-          </h1>
-          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Michler, J.D. (2020). "Agriculture in the Process of Development: A
+          <p class="hero-biblio" style="font-size: 1.5rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Michler, J.D. (2020). "Agriculture in the Process of Development: A
             Micro-Perspective." World Development 129: 104888.</p>
         </div>
       </div>

--- a/beasts-field-ethics-agricultural-and-applied-economics.html
+++ b/beasts-field-ethics-agricultural-and-applied-economics.html
@@ -107,12 +107,9 @@
         alt="Background"
         class="hero-bg"
       />
-      <div class="container relative z-10">
+      <div class="container relative z-10" style="max-width: 800px; margin: 0 auto;">
         <div class="hero-content">
-          <h1>
-            Beasts of the Field? Ethics in Agricultural and Applied Economics
-          </h1>
-          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Josephson, A., and Michler, J.D. (2018). "Beasts of the Field?
+          <p class="hero-biblio" style="font-size: 1.5rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Josephson, A., and Michler, J.D. (2018). "Beasts of the Field?
             Ethics in Agricultural and Applied Economics." Food Policy 79: 1-11.</p>
         </div>
       </div>

--- a/conservation-agriculture-and-climate-resilience.html
+++ b/conservation-agriculture-and-climate-resilience.html
@@ -106,10 +106,9 @@
         alt="Background"
         class="hero-bg"
       />
-      <div class="container relative z-10">
+      <div class="container relative z-10" style="max-width: 800px; margin: 0 auto;">
         <div class="hero-content">
-          <h1>Conservation Agriculture and Climate Resilience</h1>
-          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Michler, J.D., Baylis, K., Arends-Kuenning, M., and Mazvimavi, K.
+          <p class="hero-biblio" style="font-size: 1.5rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Michler, J.D., Baylis, K., Arends-Kuenning, M., and Mazvimavi, K.
             (2019). "Conservation Agriculture and Climate Resilience." Journal
             of Environmental Economics and Management 93: 148-69.</p>
         </div>

--- a/contract-farming-and-rural-transformation.html
+++ b/contract-farming-and-rural-transformation.html
@@ -106,10 +106,9 @@
         alt="Background"
         class="hero-bg"
       />
-      <div class="container relative z-10">
+      <div class="container relative z-10" style="max-width: 800px; margin: 0 auto;">
         <div class="hero-content">
-          <h1>Contract Farming and Rural Transformation</h1>
-          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Arouna, A., J.D. Michler, and J.C. Lokossou (2021). "Contract
+          <p class="hero-biblio" style="font-size: 1.5rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Arouna, A., J.D. Michler, and J.C. Lokossou (2021). "Contract
             farming and rural transformation: Evidence from a field experiment
             in Benin." Journal of Development Economics 151: 102626.</p>
         </div>

--- a/coping-or-hoping.html
+++ b/coping-or-hoping.html
@@ -101,10 +101,9 @@
         alt="Background"
         class="hero-bg"
       />
-      <div class="container relative z-10">
+      <div class="container relative z-10" style="max-width: 800px; margin: 0 auto;">
         <div class="hero-content">
-          <h1>Coping or Hoping</h1>
-          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Furbush, A., Josephson, A., Kilic, T., and Michler, J.D. (2025).
+          <p class="hero-biblio" style="font-size: 1.5rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Furbush, A., Josephson, A., Kilic, T., and Michler, J.D. (2025).
             "Coping or Hoping? Livelihood Diversification and Food Insecurity in
             the COVID-19 Pandemic." Food Policy 131: 102819.</p>
         </div>

--- a/cost-climate-action.html
+++ b/cost-climate-action.html
@@ -97,10 +97,9 @@
     <!-- Page Header -->
     <header class="hero" style="min-height: 50vh">
       <img src="photos/IMG_7551.webp" alt="Background" class="hero-bg" />
-      <div class="container relative z-10">
+      <div class="container relative z-10" style="max-width: 800px; margin: 0 auto;">
         <div class="hero-content">
-          <h1>Cost of Climate Action</h1>
-          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);"></p>
+          <p class="hero-biblio" style="font-size: 1.5rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);"></p>
         </div>
       </div>
     </header>

--- a/economics-climate-adaptation.html
+++ b/economics-climate-adaptation.html
@@ -97,10 +97,9 @@
     <!-- Page Header -->
     <header class="hero" style="min-height: 50vh">
       <img src="photos/IMG_7551.webp" alt="Background" class="hero-bg" />
-      <div class="container relative z-10">
+      <div class="container relative z-10" style="max-width: 800px; margin: 0 auto;">
         <div class="hero-content">
-          <h1>The Economics of Climate Adaptation</h1>
-          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);"></p>
+          <p class="hero-biblio" style="font-size: 1.5rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);"></p>
         </div>
       </div>
     </header>

--- a/evolving-impact-covid-19-four-african-countries.html
+++ b/evolving-impact-covid-19-four-african-countries.html
@@ -103,10 +103,9 @@
     <!-- Page Header -->
     <header class="hero" style="min-height: 50vh">
       <img src="photos/IMG_7551.webp" alt="Background" class="hero-bg" />
-      <div class="container relative z-10">
+      <div class="container relative z-10" style="max-width: 800px; margin: 0 auto;">
         <div class="hero-content">
-          <h1>The Evolving Impact of COVID-19 in Four African Countries</h1>
-          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Furbush, A., Josephson, A., Kilic, T., and Michler, J.D. (2021).
+          <p class="hero-biblio" style="font-size: 1.5rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Furbush, A., Josephson, A., Kilic, T., and Michler, J.D. (2021).
             "The Evolving Impact of COVID-19 in Four African Countries," in R.
             Arezki, S. Djankov, and U. Panizza, eds., Shaping Africa’s
             Post-Covid Recovery. London: CEPR Press.</p>

--- a/expanding-undergraduate-research-experience.html
+++ b/expanding-undergraduate-research-experience.html
@@ -106,10 +106,9 @@
         alt="Background"
         class="hero-bg"
       />
-      <div class="container relative z-10">
+      <div class="container relative z-10" style="max-width: 800px; margin: 0 auto;">
         <div class="hero-content">
-          <h1>Expanding Undergraduate Research Experience</h1>
-          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Athnos, A., Josephson, A., Michler, J.D., and Rudin-Rush, L. (2024).
+          <p class="hero-biblio" style="font-size: 1.5rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Athnos, A., Josephson, A., Michler, J.D., and Rudin-Rush, L. (2024).
             "Expanding Undergraduate Research Experience: Opportunities,
             Challenges, and Lessons for the Future." Applied Economics Teaching
             Resources, forthcoming.</p>

--- a/exploring-crop-yield-dynamics-across-sub-saharan-africa-six-country-study.html
+++ b/exploring-crop-yield-dynamics-across-sub-saharan-africa-six-country-study.html
@@ -103,13 +103,9 @@
     <!-- Page Header -->
     <header class="hero" style="min-height: 50vh">
       <img src="photos/IMG_7551.webp" alt="Background" class="hero-bg" />
-      <div class="container relative z-10">
+      <div class="container relative z-10" style="max-width: 800px; margin: 0 auto;">
         <div class="hero-content">
-          <h1>
-            Exploring Crop Yield Dynamics Across Sub-Saharan Africa: A Six
-            Country Study
-          </h1>
-          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);"></p>
+          <p class="hero-biblio" style="font-size: 1.5rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);"></p>
         </div>
       </div>
     </header>

--- a/farmer-family-firms-and-missing-markets.html
+++ b/farmer-family-firms-and-missing-markets.html
@@ -100,10 +100,9 @@
     <!-- Page Header -->
     <header class="hero" style="min-height: 50vh">
       <img src="photos/IMG_7551.webp" alt="Background" class="hero-bg" />
-      <div class="container relative z-10">
+      <div class="container relative z-10" style="max-width: 800px; margin: 0 auto;">
         <div class="hero-content">
-          <h1>Farmer Family Firms and Missing Markets</h1>
-          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Kee-Tui, E., Josephson, A., and Michler, J.D. "Farmer Family Firms
+          <p class="hero-biblio" style="font-size: 1.5rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Kee-Tui, E., Josephson, A., and Michler, J.D. "Farmer Family Firms
             and Missing Markets: Evidence from the Philippines, 1970-2016."</p>
         </div>
       </div>

--- a/food-insecurity-during-first-year-covid-19-pandemic-four-african-countries.html
+++ b/food-insecurity-during-first-year-covid-19-pandemic-four-african-countries.html
@@ -107,13 +107,9 @@
         alt="Background"
         class="hero-bg"
       />
-      <div class="container relative z-10">
+      <div class="container relative z-10" style="max-width: 800px; margin: 0 auto;">
         <div class="hero-content">
-          <h1>
-            Food Insecurity During the First Year of the COVID-19 Pandemic in
-            Four African Countries
-          </h1>
-          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Rudin-Rush, L., J.D. Michler, A. Josephson, and J.R. Bloem. (2022).
+          <p class="hero-biblio" style="font-size: 1.5rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Rudin-Rush, L., J.D. Michler, A. Josephson, and J.R. Bloem. (2022).
             "Food Insecurity During the First Year of the COVID-19 Pandemic in
             Four African Countries." Food Policy 111: 102306.</p>
         </div>

--- a/food-without-fire.html
+++ b/food-without-fire.html
@@ -101,10 +101,9 @@
         alt="Background"
         class="hero-bg"
       />
-      <div class="container relative z-10">
+      <div class="container relative z-10" style="max-width: 800px; margin: 0 auto;">
         <div class="hero-content">
-          <h1>Food Without Fire</h1>
-          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">McCann, L., Michler, J.D., Mwangala, M., Olurotimi, O., and Estrada
+          <p class="hero-biblio" style="font-size: 1.5rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">McCann, L., Michler, J.D., Mwangala, M., Olurotimi, O., and Estrada
             Carmona, N. (2025). "Food Without Fire: Environmental and
             Nutritional Impacts from a Solar Stove Field Experiment." American
             Journal of Agricultural Economics.</p>

--- a/impact-evaluations-data-poor-settings.html
+++ b/impact-evaluations-data-poor-settings.html
@@ -104,10 +104,9 @@
         alt="Background"
         class="hero-bg"
       />
-      <div class="container relative z-10">
+      <div class="container relative z-10" style="max-width: 800px; margin: 0 auto;">
         <div class="hero-content">
-          <h1>Impact Evaluations in Data Poor Settings</h1>
-          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Michler, J.D., Al Rafi, D.A., Giezendanner, J., Josephson, A., Pede,
+          <p class="hero-biblio" style="font-size: 1.5rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Michler, J.D., Al Rafi, D.A., Giezendanner, J., Josephson, A., Pede,
             V.O., and Tellman, E. (2026). "Impact Evaluations in Data Poor
             Settings: The Case of Stress-Tolerant Rice Varieties in Bangladesh."
             Journal of Development Economics: 103648.</p>

--- a/intra-household-inequality-food-expenditures-and-diet-quality-philippines.html
+++ b/intra-household-inequality-food-expenditures-and-diet-quality-philippines.html
@@ -103,13 +103,9 @@
     <!-- Page Header -->
     <header class="hero" style="min-height: 50vh">
       <img src="photos/IMG_7551.webp" alt="Background" class="hero-bg" />
-      <div class="container relative z-10">
+      <div class="container relative z-10" style="max-width: 800px; margin: 0 auto;">
         <div class="hero-content">
-          <h1>
-            Intra-household inequality in food expenditures and diet quality in
-            the Philippines
-          </h1>
-          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);"></p>
+          <p class="hero-biblio" style="font-size: 1.5rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);"></p>
         </div>
       </div>
     </header>

--- a/intra-household-management-joint-resources.html
+++ b/intra-household-management-joint-resources.html
@@ -102,10 +102,9 @@
     <!-- Page Header -->
     <header class="hero" style="min-height: 50vh">
       <img src="photos/IMG_7551.webp" alt="Background" class="hero-bg" />
-      <div class="container relative z-10">
+      <div class="container relative z-10" style="max-width: 800px; margin: 0 auto;">
         <div class="hero-content">
-          <h1>Intra-Household Management of Joint Resources</h1>
-          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);"></p>
+          <p class="hero-biblio" style="font-size: 1.5rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);"></p>
         </div>
       </div>
     </header>

--- a/mismeasure-weather.html
+++ b/mismeasure-weather.html
@@ -101,10 +101,9 @@
         alt="Background"
         class="hero-bg"
       />
-      <div class="container relative z-10">
+      <div class="container relative z-10" style="max-width: 800px; margin: 0 auto;">
         <div class="hero-content">
-          <h1>The Mismeasure of Weather</h1>
-          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Josephson, A., Michler, J.D., Kilic, T., and Murray, S. (2026). "The
+          <p class="hero-biblio" style="font-size: 1.5rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Josephson, A., Michler, J.D., Kilic, T., and Murray, S. (2026). "The
             Mismeasure of Weather: Using Earth Observation Data for Estimation
             of Socioeconomic Outcomes." Journal of Development Economics 178:
             103553.</p>

--- a/money-matters-role-yields-and-profits-agricultural-technology-adoption.html
+++ b/money-matters-role-yields-and-profits-agricultural-technology-adoption.html
@@ -107,13 +107,9 @@
         alt="Background"
         class="hero-bg"
       />
-      <div class="container relative z-10">
+      <div class="container relative z-10" style="max-width: 800px; margin: 0 auto;">
         <div class="hero-content">
-          <h1>
-            Money Matters: The Role of Yields and Profits in Agricultural
-            Technology Adoption
-          </h1>
-          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Michler, J.D., Tjernström, E., Verkaart, S. and Mausch, K. (2019).
+          <p class="hero-biblio" style="font-size: 1.5rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Michler, J.D., Tjernström, E., Verkaart, S. and Mausch, K. (2019).
             "Money Matters: The Role of Yields and Profits in Agricultural
             Technology Adoption." American Journal of Agricultural Economics 101
             (3): 710-31.</p>

--- a/one-size-fits-all.html
+++ b/one-size-fits-all.html
@@ -101,10 +101,9 @@
         alt="Background"
         class="hero-bg"
       />
-      <div class="container relative z-10">
+      <div class="container relative z-10" style="max-width: 800px; margin: 0 auto;">
         <div class="hero-content">
-          <h1>One Size Fits All</h1>
-          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Arouna, A., J.D. Michler, W.G. Yergo, and K. Saito. 2021. “One Size
+          <p class="hero-biblio" style="font-size: 1.5rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Arouna, A., J.D. Michler, W.G. Yergo, and K. Saito. 2021. “One Size
             Fits All? Experimental Evidence on the Digital Delivery of
             Personalized Extension Advice in Nigeria.” American Journal of
             Agricultural Economics 103 (2): 596-619.</p>

--- a/privacy-protection-measurement-error-and-integration-remote-sensing-and-socioeconomic-survey-data.html
+++ b/privacy-protection-measurement-error-and-integration-remote-sensing-and-socioeconomic-survey-data.html
@@ -107,13 +107,9 @@
         alt="Background"
         class="hero-bg"
       />
-      <div class="container relative z-10">
+      <div class="container relative z-10" style="max-width: 800px; margin: 0 auto;">
         <div class="hero-content">
-          <h1>
-            Privacy Protection, Measurement Error, and the Integration of Remote
-            Sensing and Socioeconomic Survey Data
-          </h1>
-          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Michler, J.D., Josephson, A., Kilic, T., and Murray, S. (2022).
+          <p class="hero-biblio" style="font-size: 1.5rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Michler, J.D., Josephson, A., Kilic, T., and Murray, S. (2022).
             "Privacy Protection, Measurement Error, and the Integration of
             Remote Sensing and Socioeconomic Survey Data." Journal of
             Development Economics 158: 102927.</p>

--- a/recent-developments-inference-practicalities-applied-economics.html
+++ b/recent-developments-inference-practicalities-applied-economics.html
@@ -103,13 +103,9 @@
     <!-- Page Header -->
     <header class="hero" style="min-height: 50vh">
       <img src="photos/IMG_7551.webp" alt="Background" class="hero-bg" />
-      <div class="container relative z-10">
+      <div class="container relative z-10" style="max-width: 800px; margin: 0 auto;">
         <div class="hero-content">
-          <h1>
-            Recent developments in inference: practicalities for applied
-            economics
-          </h1>
-          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Michler, J.D. and A. Josephson. (2022). "Recent Developments in
+          <p class="hero-biblio" style="font-size: 1.5rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Michler, J.D. and A. Josephson. (2022). "Recent Developments in
             Inference: Practicalities for the Applied Economist." In J. Roosen
             and J.E. Hobbs, eds., A Modern Guide to Food Economics. Cheltenham:
             Edward Elgar Publishing.</p>

--- a/research-ethics-beyond-irb-selection-bias-and-direction-innovation-applied-economics.html
+++ b/research-ethics-beyond-irb-selection-bias-and-direction-innovation-applied-economics.html
@@ -107,13 +107,9 @@
         alt="Background"
         class="hero-bg"
       />
-      <div class="container relative z-10">
+      <div class="container relative z-10" style="max-width: 800px; margin: 0 auto;">
         <div class="hero-content">
-          <h1>
-            Research ethics beyond the IRB: Selection bias and the direction of
-            innovation in applied economics
-          </h1>
-          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Michler, J.D., Masters, W.A., and Josephson, A. (2021). "Research
+          <p class="hero-biblio" style="font-size: 1.5rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Michler, J.D., Masters, W.A., and Josephson, A. (2021). "Research
             Ethics Beyond the IRB: Selection Bias and the Direction of
             Innovation in Applied Economics." Applied Economic Perspectives and
             Policy 43 (4): 1352-65.</p>

--- a/risk-and-rainfall-specification-sensitivity-estimating-smallholder-risk-preferences.html
+++ b/risk-and-rainfall-specification-sensitivity-estimating-smallholder-risk-preferences.html
@@ -103,13 +103,9 @@
     <!-- Page Header -->
     <header class="hero" style="min-height: 50vh">
       <img src="photos/IMG_7551.webp" alt="Background" class="hero-bg" />
-      <div class="container relative z-10">
+      <div class="container relative z-10" style="max-width: 800px; margin: 0 auto;">
         <div class="hero-content">
-          <h1>
-            Risk and Rainfall: Specification Sensitivity in Estimating
-            Smallholder Risk Preferences
-          </h1>
-          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);"></p>
+          <p class="hero-biblio" style="font-size: 1.5rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);"></p>
         </div>
       </div>
     </header>

--- a/socioeconomic-impacts-covid-19-low-income-countries.html
+++ b/socioeconomic-impacts-covid-19-low-income-countries.html
@@ -107,10 +107,9 @@
         alt="Background"
         class="hero-bg"
       />
-      <div class="container relative z-10">
+      <div class="container relative z-10" style="max-width: 800px; margin: 0 auto;">
         <div class="hero-content">
-          <h1>Socioeconomic Impacts of COVID-19 in Low-Income Countries</h1>
-          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Josephson, A., T. Kilic, and J.D. Michler. (2021). Socioeconomic
+          <p class="hero-biblio" style="font-size: 1.5rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Josephson, A., T. Kilic, and J.D. Michler. (2021). Socioeconomic
             Impacts of COVID-19 in Low-Income Countries." Nature Human Behaviour
             5: 557-65.</p>
         </div>

--- a/specialize-or-diversify-agricultural-diversity-and-poverty-dynamics-ethiopia.html
+++ b/specialize-or-diversify-agricultural-diversity-and-poverty-dynamics-ethiopia.html
@@ -107,13 +107,9 @@
         alt="Background"
         class="hero-bg"
       />
-      <div class="container relative z-10">
+      <div class="container relative z-10" style="max-width: 800px; margin: 0 auto;">
         <div class="hero-content">
-          <h1>
-            To Specialize or Diversify: Agricultural Diversity and Poverty
-            Dynamics in Ethiopia
-          </h1>
-          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Michler, J.D. and Josephson, A. (2017).  "To Specialize or
+          <p class="hero-biblio" style="font-size: 1.5rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Michler, J.D. and Josephson, A. (2017).  "To Specialize or
             Diversify: Agricultural Diversity and Poverty Dynamics in Ethiopia."
             World Development 89: 214-26.</p>
         </div>

--- a/ulysses-pact-or-ulysses-raft-using-pre-analysis-plans-experimental-and-nonexperimental-research.html
+++ b/ulysses-pact-or-ulysses-raft-using-pre-analysis-plans-experimental-and-nonexperimental-research.html
@@ -103,13 +103,9 @@
     <!-- Page Header -->
     <header class="hero" style="min-height: 50vh">
       <img src="photos/IMG_7551.webp" alt="Background" class="hero-bg" />
-      <div class="container relative z-10">
+      <div class="container relative z-10" style="max-width: 800px; margin: 0 auto;">
         <div class="hero-content">
-          <h1>
-            Ulysses' Pact or Ulysses' Raft: Using Pre-Analysis Plans in
-            Experimental and Nonexperimental Research
-          </h1>
-          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Janzen, S. and Michler, J.D. (2021). "Ulysses' Pact or Ulysses'
+          <p class="hero-biblio" style="font-size: 1.5rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);">Janzen, S. and Michler, J.D. (2021). "Ulysses' Pact or Ulysses'
             Raft: Using Pre-Analysis Plans in Experimental and Nonexperimental
             Research." Applied Economic Perspectives and Policy 43 (4):
             1286-1304.</p>

--- a/variable-selection-economic-applications-remotely-sensed-weather-data.html
+++ b/variable-selection-economic-applications-remotely-sensed-weather-data.html
@@ -103,13 +103,9 @@
     <!-- Page Header -->
     <header class="hero" style="min-height: 50vh">
       <img src="photos/IMG_7551.webp" alt="Background" class="hero-bg" />
-      <div class="container relative z-10">
+      <div class="container relative z-10" style="max-width: 800px; margin: 0 auto;">
         <div class="hero-content">
-          <h1>
-            Variable Selection in Economic Applications of Remotely Sensed
-            Weather Data
-          </h1>
-          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);"></p>
+          <p class="hero-biblio" style="font-size: 1.5rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);"></p>
         </div>
       </div>
     </header>

--- a/what-do-you-mean-informed-consent-ethics-economic-development-research.html
+++ b/what-do-you-mean-informed-consent-ethics-economic-development-research.html
@@ -103,13 +103,9 @@
     <!-- Page Header -->
     <header class="hero" style="min-height: 50vh">
       <img src="photos/IMG_7551.webp" alt="Background" class="hero-bg" />
-      <div class="container relative z-10">
+      <div class="container relative z-10" style="max-width: 800px; margin: 0 auto;">
         <div class="hero-content">
-          <h1>
-            What Do you Mean by “Informed Consent”? Ethics in Economic
-            Development Research
-          </h1>
-          <p class="hero-biblio" style="font-size: 1.1rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);"></p>
+          <p class="hero-biblio" style="font-size: 1.5rem; font-style: italic; margin-top: 1rem; color: rgba(255,255,255,0.9);"></p>
         </div>
       </div>
     </header>


### PR DESCRIPTION
- Removed large paper titles from the top hero section.
- Increased citation font size to 1.5rem for better readability.
- Aligned citations with the abstracts below by applying max-width: 800px and auto margins to their containers.

---
*PR created automatically by Jules for task [13361323142354123986](https://jules.google.com/task/13361323142354123986) started by @jdavidm*