### PR TITLE
Fix hero image opacity and publication links

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,107 +1,78 @@
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Jeffrey D. Michler | Applied Economist</title>
-    <meta
-      name="description"
-      content="Personal website of Jeffrey D. Michler. Associate Professor of Agricultural and Applied Economics at the University of Arizona."
-    />
-    <!-- Google Fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Merriweather:ital,wght@0,300;0,400;1,300&display=swap"
-      rel="stylesheet"
-    />
-    <!-- FontAwesome for Icons -->
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
-    />
-    <!-- Core CSS -->
-    <link rel="stylesheet" href="style.css" />
-      <link rel="preload" as="image" href="photos/IMG_8410-2.webp" />
-</head>
-  <body>
-    <!-- Navigation -->
-    <nav class="navbar">
-      <div class="container nav-container">
-        <a href="index.html" class="nav-logo">Jeffrey D. Michler</a>
-        <ul class="nav-links">
-          <li><a href="index.html" class="nav-link active">Home</a></li>
-          <li><a href="cv.html" class="nav-link">CV & Bio</a></li>
-          <li><a href="publications.html" class="nav-link">Publications</a></li>
-          <li><a href="teaching.html" class="nav-link">Teaching</a></li>
-          <li><a href="software.html" class="nav-link">Software</a></li>
-          <li>
-            <a
-              href="https://aidelab.arizona.edu/"
-              class="nav-link"
-              target="_blank" rel="noopener noreferrer"
-              >AIDE Lab
-              <i
-                class="fas fa-external-link-alt"
-                style="font-size: 0.8em; margin-left: 4px"
-              ></i
-            ></a>
-          </li>
-        </ul>
-      </div>
-    </nav>
+<!DOCTYPE html>
 
-    <!-- Hero Section -->
-    <header class="hero">
-      <!-- Using a placeholder background image for now -->
-      <img
-        src="photos/IMG_8410-2.webp"
-        alt="Hero Background"
-        class="hero-bg"
-        onerror="
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<title>Jeffrey D. Michler | Applied Economist</title>
+<meta content="Personal website of Jeffrey D. Michler. Associate Professor of Agricultural and Applied Economics at the University of Arizona." name="description"/>
+<!-- Google Fonts -->
+<link href="https://fonts.googleapis.com" rel="preconnect"/>
+<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&amp;family=Merriweather:ital,wght@0,300;0,400;1,300&amp;display=swap" rel="stylesheet"/>
+<!-- FontAwesome for Icons -->
+<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet"/>
+<!-- Core CSS -->
+<link href="style.css" rel="stylesheet"/>
+<link as="image" href="photos/IMG_8410-2.webp" rel="preload"/>
+</head>
+<body>
+<!-- Navigation -->
+<nav class="navbar">
+<div class="container nav-container">
+<a class="nav-logo" href="index.html">Jeffrey D. Michler</a>
+<ul class="nav-links">
+<li><a class="nav-link active" href="index.html">Home</a></li>
+<li><a class="nav-link" href="cv.html">CV &amp; Bio</a></li>
+<li><a class="nav-link" href="publications.html">Publications</a></li>
+<li><a class="nav-link" href="teaching.html">Teaching</a></li>
+<li><a class="nav-link" href="software.html">Software</a></li>
+<li>
+<a class="nav-link" href="https://aidelab.arizona.edu/" rel="noopener noreferrer" target="_blank">AIDE Lab
+              <i class="fas fa-external-link-alt" style="font-size: 0.8em; margin-left: 4px"></i></a>
+</li>
+</ul>
+</div>
+</nav>
+<!-- Hero Section -->
+<header class="hero">
+<!-- Using a placeholder background image for now -->
+<img alt="Hero Background" class="hero-bg" onerror="
           this.src =
             'https://source.unsplash.com/random/1600x900/?agriculture,farm'
-        "
-      />
-      <div class="container relative z-10">
-        <div class="hero-content">
-          <h1>Jeffrey D. Michler</h1>
-          <p class="subtitle">Applied Economist & Associate Professor</p>
-          <p class="bio-snippet">
+        " src="photos/IMG_8410-2.webp"/>
+<div class="container relative z-10">
+<div class="hero-content">
+<h1>Jeffrey D. Michler</h1>
+<p class="subtitle">Applied Economist &amp; Associate Professor</p>
+<p class="bio-snippet">
             My research focuses on the microeconomics of agricultural
             development, emphasizing issues of risk, technology adoption, and
             food security in developing economies.
           </p>
-          <div class="flex" style="gap: 1rem; margin-top: 2rem">
-            <a href="cv.html" class="btn btn-primary">View Full CV</a>
-            <a href="publications.html" class="btn btn-outline"
-              >Read Publications</a
-            >
-          </div>
-        </div>
-      </div>
-    </header>
-
-    <!-- Main Content Area -->
-    <main>
-      <!-- About Section -->
-      <section class="section section-alt" id="about">
-        <div class="container">
-          <div class="split-section animate-on-scroll">
-            <div>
-              <h2>About Me</h2>
-              <p>
+<div class="flex" style="gap: 1rem; margin-top: 2rem">
+<a class="btn btn-primary" href="cv.html">View Full CV</a>
+<a class="btn btn-outline" href="publications.html">Read Publications</a>
+</div>
+</div>
+</div>
+</header>
+<!-- Main Content Area -->
+<main>
+<!-- About Section -->
+<section class="section section-alt" id="about">
+<div class="container">
+<div class="split-section animate-on-scroll">
+<div>
+<h2>About Me</h2>
+<p>
                 I am an Associate Professor in the
-                <a href="https://aaec.arizona.edu/"
-                  >Department of Agricultural and Applied Economics</a
-                >
+                <a href="https://aaec.arizona.edu/">Department of Agricultural and Applied Economics</a>
                 at the <strong>University of Arizona</strong>. I am also the
                 founder and co-director of the
-                <a href="https://aidelab.arizona.edu/"
-                  >Applied International Development Economics (AIDE) Lab</a
-                >.
+                <a href="https://aidelab.arizona.edu/">Applied International Development Economics (AIDE) Lab</a>.
               </p>
-              <p>
+<p>
                 My work seeks to understand the social and economic processes
                 behind environmental change and agricultural technology
                 adoption. I use a combination of primary survey data, remote
@@ -109,190 +80,111 @@
                 that aim to improve human well-being, particularly in
                 data-scarce environments.
               </p>
-
-              <h4 style="margin-top: 2rem">Current Editorial Appointments</h4>
-              <div class="badge-list">
-                <a
-                  href="https://onlinelibrary.wiley.com/journal/14678276"
-                  target="_blank" rel="noopener noreferrer"
-                  class="badge badge-link"
-                  >Associate Editor, American Journal of Agricultural Economics
-                  (2026-)</a
-                >
-                <a
-                  href="https://academic.oup.com/erae"
-                  target="_blank" rel="noopener noreferrer"
-                  class="badge badge-link"
-                  >Associate Editor, European Review of Agricultural Economics
-                  (2024-)</a
-                >
-                <a
-                  href="https://onlinelibrary.wiley.com/journal/15740862"
-                  target="_blank" rel="noopener noreferrer"
-                  class="badge badge-link"
-                  >Associate Editor, Agricultural Economics (2023-)</a
-                >
-              </div>
-            </div>
-            <div
-              class="profile-img-container"
-              style="width: 66.66%; margin: 0 auto"
-            >
-              <!-- Using a generic image path; replace with exact headshot filename if different -->
-              <img
-                src="photos/profile.jpg"
-                alt="Jeffrey D. Michler"
-                class="profile-img"
-                onerror="
+<h4 style="margin-top: 2rem">Current Editorial Appointments</h4>
+<div class="badge-list">
+<a class="badge badge-link" href="https://onlinelibrary.wiley.com/journal/14678276" rel="noopener noreferrer" target="_blank">Associate Editor, American Journal of Agricultural Economics
+                  (2026-)</a>
+<a class="badge badge-link" href="https://academic.oup.com/erae" rel="noopener noreferrer" target="_blank">Associate Editor, European Review of Agricultural Economics
+                  (2024-)</a>
+<a class="badge badge-link" href="https://onlinelibrary.wiley.com/journal/15740862" rel="noopener noreferrer" target="_blank">Associate Editor, Agricultural Economics (2023-)</a>
+</div>
+</div>
+<div class="profile-img-container" style="width: 66.66%; margin: 0 auto">
+<!-- Using a generic image path; replace with exact headshot filename if different -->
+<img alt="Jeffrey D. Michler" class="profile-img" onerror="
                   this.src =
                     'https://via.placeholder.com/600x600?text=Profile+Photo'
-                "
-              />
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <!-- Affiliations & Quick Links -->
-      <section class="section">
-        <div class="container animate-on-scroll">
-          <div style="text-align: center; margin-bottom: 3rem">
-            <h2>Affiliations</h2>
-            <p>Organizations and initiatives I contribute to.</p>
-          </div>
-
-          <div
-            class="grid"
-            style="grid-template-columns: repeat(auto-fit, minmax(300px, 1fr))"
-          >
-            <div class="card">
-              <i
-                class="fas fa-university"
-                style="
+                " src="photos/profile.jpg"/>
+</div>
+</div>
+</div>
+</section>
+<!-- Affiliations & Quick Links -->
+<section class="section">
+<div class="container animate-on-scroll">
+<div style="text-align: center; margin-bottom: 3rem">
+<h2>Affiliations</h2>
+<p>Organizations and initiatives I contribute to.</p>
+</div>
+<div class="grid" style="grid-template-columns: repeat(auto-fit, minmax(300px, 1fr))">
+<div class="card">
+<i class="fas fa-university" style="
                   font-size: 2.5rem;
                   color: var(--color-primary);
                   margin-bottom: 1rem;
-                "
-              ></i>
-              <h3 class="card-title">University of Arizona</h3>
-              <p class="card-meta">Associate Professor, AAE (2022-present)</p>
-              <p class="card-meta">
+                "></i>
+<h3 class="card-title">University of Arizona</h3>
+<p class="card-meta">Associate Professor, AAE (2022-present)</p>
+<p class="card-meta">
                 Affiliate, Arizona Institute for Resilience (2020-2025)
               </p>
-              <p class="card-meta">
+<p class="card-meta">
                 Affiliate, Humanitarian Assistance Technical Support (2020-2025)
               </p>
-            </div>
-
-            <div class="card">
-              <i
-                class="fas fa-globe"
-                style="
+</div>
+<div class="card">
+<i class="fas fa-globe" style="
                   font-size: 2.5rem;
                   color: var(--color-primary);
                   margin-bottom: 1rem;
-                "
-              ></i>
-              <h3 class="card-title">Global Initiatives</h3>
-              <p class="card-meta">
+                "></i>
+<h3 class="card-title">Global Initiatives</h3>
+<p class="card-meta">
                 Country Affiliate, Standing Panel on Impact Assessment (2025-)
               </p>
-              <p class="card-meta">
+<p class="card-meta">
                 Catalyst, Berkeley Initiative for Transparency in the Social
                 Sciences (2020-)
               </p>
-              <p class="card-meta">
+<p class="card-meta">
                 Short-Term Consultant, World Bank (2019-2022)
               </p>
-            </div>
-
-            <div class="card">
-              <i
-                class="fas fa-book-open"
-                style="
+</div>
+<div class="card">
+<i class="fas fa-book-open" style="
                   font-size: 2.5rem;
                   color: var(--color-primary);
                   margin-bottom: 1rem;
-                "
-              ></i>
-              <h3 class="card-title">Book Release</h3>
-              <p>Co-authored with Anna Josephson.</p>
-              <p class="card-meta">
-                <strong
-                  >Research Ethics in Applied Economics: A Practical
-                  Guide</strong
-                >
-              </p>
-              <a
-                href="https://www.routledge.com/Research-Ethics-in-Applied-Economics-A-Practical-Guide/Josephson-Michler/p/book/9780367457419"
-                class="btn btn-outline-dark"
-                style="margin-top: auto"
-                target="_blank" rel="noopener noreferrer"
-                >View on Routledge
-                <i
-                  class="fas fa-external-link-alt"
-                  style="margin-left: 0.5rem; font-size: 0.8em"
-                ></i
-              ></a>
-            </div>
-          </div>
-        </div>
-      </section>
-    </main>
-
-    <!-- Footer -->
-    <footer class="footer">
-      <div class="container footer-content">
-        <div>
-          <p>
-            &copy;
+                "></i>
+<h3 class="card-title">Book Release</h3>
+<p>Co-authored with Anna Josephson.</p>
+<p class="card-meta">
+<strong>Research Ethics in Applied Economics: A Practical
+                  Guide</strong>
+</p>
+<a class="btn btn-outline-dark" href="https://www.routledge.com/Research-Ethics-in-Applied-Economics-A-Practical-Guide/Josephson-Michler/p/book/9780367457419" rel="noopener noreferrer" style="margin-top: auto" target="_blank">View on Routledge
+                <i class="fas fa-external-link-alt" style="margin-left: 0.5rem; font-size: 0.8em"></i></a>
+</div>
+</div>
+</div>
+</section>
+</main>
+<!-- Footer -->
+<footer class="footer">
+<div class="container footer-content">
+<div>
+<p>
+            ©
             <script>
               document.write(new Date().getFullYear());
             </script>
             Jeffrey D. Michler. All rights reserved.
           </p>
-          <p style="color: var(--color-text-muted); font-size: 0.9rem">
+<p style="color: var(--color-text-muted); font-size: 0.9rem">
             McClelland Park 301K | Tucson, AZ 85721 |
-            <a
-              href="mailto:jdmichler@arizona.edu"
-              style="color: var(--color-text-muted); text-decoration: underline"
-              >jdmichler@arizona.edu</a
-            >
-          </p>
-        </div>
-        <div class="social-links">
-          <a href="mailto:jdmichler@arizona.edu" title="Email"
-            ><i class="fas fa-envelope"></i
-          ></a>
-          <a
-            href="https://aaec.arizona.edu/person/jeffrey-d-michler"
-            title="Departmental Website"
-            target="_blank" rel="noopener noreferrer"
-            ><i class="fas fa-university"></i
-          ></a>
-          <a
-            href="https://orcid.org/0000-0001-7778-8703"
-            title="ORCiD"
-            target="_blank" rel="noopener noreferrer"
-            ><i class="fab fa-orcid"></i
-          ></a>
-          <a
-            href="https://scholar.google.com/citations?user=akcW2fkAAAAJ"
-            title="Google Scholar"
-            target="_blank" rel="noopener noreferrer"
-            ><i class="fas fa-graduation-cap"></i
-          ></a>
-          <a
-            href="https://github.com/jdavidm"
-            title="GitHub"
-            target="_blank" rel="noopener noreferrer"
-            ><i class="fab fa-github"></i
-          ></a>
-        </div>
-      </div>
-    </footer>
-
-    <!-- Core JS -->
-    <script src="main.js"></script>
-  </body>
+            <a href="mailto:jdmichler@arizona.edu" style="color: var(--color-text-muted); text-decoration: underline">jdmichler@arizona.edu</a>
+</p>
+</div>
+<div class="social-links">
+<a href="mailto:jdmichler@arizona.edu" title="Email"><i class="fas fa-envelope"></i></a>
+<a href="https://aaec.arizona.edu/person/jeffrey-d-michler" rel="noopener noreferrer" target="_blank" title="Departmental Website"><i class="fas fa-university"></i></a>
+<a href="https://orcid.org/0000-0001-7778-8703" rel="noopener noreferrer" target="_blank" title="ORCiD"><i class="fab fa-orcid"></i></a>
+<a href="https://scholar.google.com/citations?user=akcW2fkAAAAJ" rel="noopener noreferrer" target="_blank" title="Google Scholar"><i class="fas fa-graduation-cap"></i></a>
+<a href="https://github.com/jdavidm" rel="noopener noreferrer" target="_blank" title="GitHub"><i class="fab fa-github"></i></a>
+</div>
+</div>
+</footer>
+<!-- Core JS -->
+<script src="main.js"></script>
+</body>
 </html>

--- a/publications.html
+++ b/publications.html
@@ -115,7 +115,7 @@
 <li><a class="nav-link" href="teaching.html">Teaching</a></li>
 <li><a class="nav-link" href="software.html">Software</a></li>
 <li>
-<a class="nav-link" href="https://aidelab.arizona.edu/" rel="noopener noreferrer" target="_blank">AIDE Lab
+<a class="nav-link" href="https://aidelab.arizona.edu/" rel="noopener noreferrer">AIDE Lab
               <i class="fas fa-external-link-alt" style="font-size: 0.8em; margin-left: 4px"></i></a>
 </li>
 </ul>
@@ -768,7 +768,7 @@
             For a complete list of publications, presentations, and working
             papers, please refer to my <a href="cv.html">Curriculum Vitae</a>.
           </p>
-<a class="btn btn-primary" href="https://scholar.google.com/citations?user=akcW2fkAAAAJ" rel="noopener noreferrer" style="margin-top: 1rem" target="_blank">View Google Scholar</a>
+<a class="btn btn-primary" href="https://scholar.google.com/citations?user=akcW2fkAAAAJ" rel="noopener noreferrer" style="margin-top: 1rem">View Google Scholar</a>
 </div>
 <!-- Book Chapters Section -->
 <h2 class="section-title" style="margin-top: 3rem">Book Chapters</h2>
@@ -990,10 +990,10 @@
 </div>
 <div class="social-links">
 <a href="mailto:jdmichler@arizona.edu" title="Email"><i class="fas fa-envelope"></i></a>
-<a href="https://aaec.arizona.edu/person/jeffrey-d-michler" rel="noopener noreferrer" target="_blank" title="Departmental Website"><i class="fas fa-university"></i></a>
-<a href="https://orcid.org/0000-0001-7778-8703" rel="noopener noreferrer" target="_blank" title="ORCiD"><i class="fab fa-orcid"></i></a>
-<a href="https://scholar.google.com/citations?user=akcW2fkAAAAJ" rel="noopener noreferrer" target="_blank" title="Google Scholar"><i class="fas fa-graduation-cap"></i></a>
-<a href="https://github.com/jdavidm" rel="noopener noreferrer" target="_blank" title="GitHub"><i class="fab fa-github"></i></a>
+<a href="https://aaec.arizona.edu/person/jeffrey-d-michler" rel="noopener noreferrer" title="Departmental Website"><i class="fas fa-university"></i></a>
+<a href="https://orcid.org/0000-0001-7778-8703" rel="noopener noreferrer" title="ORCiD"><i class="fab fa-orcid"></i></a>
+<a href="https://scholar.google.com/citations?user=akcW2fkAAAAJ" rel="noopener noreferrer" title="Google Scholar"><i class="fas fa-graduation-cap"></i></a>
+<a href="https://github.com/jdavidm" rel="noopener noreferrer" title="GitHub"><i class="fab fa-github"></i></a>
 </div>
 </div>
 </footer>

--- a/style.css
+++ b/style.css
@@ -208,7 +208,7 @@ a:hover {
   height: 100%;
   object-fit: cover;
   z-index: 0;
-  opacity: 0.6; /* Darken background for text readability */
+  opacity: 0.3; /* Darken background for text readability */
 
 }
 


### PR DESCRIPTION
This PR implements two requested UI changes:
1. Publication cards on `publications.html` now open in the same tab instead of a new tab. This was achieved by removing the `target="_blank"` attributes.
2. Lightened the hero images across pages to make the overlaying text easier to read. This was done by decreasing the opacity of `.hero-bg` from 0.6 to 0.3 in `style.css`.

---
*PR created automatically by Jules for task [7804474881715746588](https://jules.google.com/task/7804474881715746588) started by @jdavidm*