### PR TITLE
Fix PR Creation Issue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Agent Instructions
+
+## Creating Pull Requests
+When asked to create, publish, or submit a Pull Request (PR), **DO NOT use `git push`**. Standard git pushing is blocked in this environment and will fail.
+
+Instead, you **MUST** use the built-in `submit` tool provided in your environment. The `submit` tool handles packaging the changes, pushing the branch, and creating the pull request on GitHub correctly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,8 @@
 When asked to create, publish, or submit a Pull Request (PR), **DO NOT use `git push`**. Standard git pushing is blocked in this environment and will fail.
 
 Instead, you **MUST** use the built-in `submit` tool provided in your environment. The `submit` tool handles packaging the changes, pushing the branch, and creating the pull request on GitHub correctly.
+
+## Important: Commit Before Submitting
+Before calling the `submit` tool to create a Pull Request, you **MUST** ensure that you have locally committed all of your changes to your working branch (e.g., using `git add` and `git commit`).
+
+The `submit` tool pushes your local commits to the remote. If you have not committed your file modifications locally, the PR will fail to create or will be empty.


### PR DESCRIPTION
The user was experiencing an issue where agents were failing to create PRs because they were attempting to use \`git push\`, which is blocked. I have provided instructions to the user to tell agents to use the \`submit\` tool instead. All existing tests pass.

---
*PR created automatically by Jules for task [11216613510568119224](https://jules.google.com/task/11216613510568119224) started by @jdavidm*