### PR TITLE
style: revert background-image linear gradient to lighter shading

### DIFF
--- a/publications.html
+++ b/publications.html
@@ -155,7 +155,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/1 - REAEP.png'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/1 - REAEP.png'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-accent); color: white">Book</span>
 <h3 class="pub-title">
               Research Ethics in Applied Economics: A Practical Guide
@@ -167,7 +167,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/2 - CSSCA.png'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/2 - CSSCA.png'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-primary-light); color: white">Journal Article</span>
 <h3 class="pub-title">
               Comment on Suri (2011) `Selection and Comparative Advantage in
@@ -194,7 +194,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/3 - IEDEC.jpg'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/3 - IEDEC.jpg'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-primary-light); color: white">Journal Article</span>
 <h3 class="pub-title">
               Impact Evaluations in Data-Scarce Environments: The Case of
@@ -221,7 +221,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/4 - MWUEO.png'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/4 - MWUEO.png'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-primary-light); color: white">Journal Article</span>
 <h3 class="pub-title">
               The Mismeasure of Weather: Using Earth Observation Data for
@@ -247,7 +247,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/5 - FWFNE.png'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/5 - FWFNE.png'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-primary-light); color: white">Journal Article</span>
 <h3 class="pub-title">
               Food Without Fire: Nutritional and Environmental Impacts from a
@@ -274,7 +274,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/6 - CHLDF.png'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/6 - CHLDF.png'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-primary-light); color: white">Journal Article</span>
 <h3 class="pub-title">
               Coping or Hoping? Livelihood Diversification and Food Insecurity
@@ -300,7 +300,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/7 - EUREO.png'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/7 - EUREO.png'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-primary-light); color: white">Journal Article</span>
 <h3 class="pub-title">
               Expanding Undergraduate Research Experience: Opportunities,
@@ -324,7 +324,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/8 - PPMEI.png'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/8 - PPMEI.png'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-primary-light); color: white">Journal Article</span>
 <h3 class="pub-title">
               Privacy Protection, Measurement Error, and the Integration of
@@ -350,7 +350,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/9 - FIDFY.png'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/9 - FIDFY.png'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-primary-light); color: white">Journal Article</span>
 <h3 class="pub-title">
               Food Insecurity During the First Year of the COVID-19 Pandemic in
@@ -367,7 +367,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/10 - RCYWI.png'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/10 - RCYWI.png'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-primary-light); color: white">Journal Article</span>
 <h3 class="pub-title">
               Risk, Crop Yields, and Weather Index Insurance in Village India.
@@ -391,7 +391,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/11 - SICLC.png'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/11 - SICLC.png'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-primary-light); color: white">Journal Article</span>
 <h3 class="pub-title">
               Socioeconomic Impacts of COVID-19 in Low-Income Countries.
@@ -414,7 +414,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/12 - CFRTE.png'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/12 - CFRTE.png'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-primary-light); color: white">Journal Article</span>
 <h3 class="pub-title">
               Contract Farming and Rural Transformation: Evidence from a Field
@@ -440,7 +440,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/13 - SFEED.png'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/13 - SFEED.png'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-primary-light); color: white">Journal Article</span>
 <h3 class="pub-title">
               One Size Fits All? Experimental Evidence on the Digital Delivery
@@ -466,7 +466,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/14 - REBSB.png'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/14 - REBSB.png'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-primary-light); color: white">Journal Article</span>
 <h3 class="pub-title">
               Research Ethics Beyond the IRB: Selection Bias and the Direction
@@ -483,7 +483,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/15 - UPURU.jpg'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/15 - UPURU.jpg'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-primary-light); color: white">Journal Article</span>
 <h3 class="pub-title">
               Ulysses' Pact or Ulysses' Raft: Using Pre-Analysis Plans in
@@ -523,7 +523,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/17 - AGRIC.png'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/17 - AGRIC.png'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-primary-light); color: white">Journal Article</span>
 <h3 class="pub-title">
               Agriculture in the Process of Development: A Micro-Perspective.
@@ -537,7 +537,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/18 - RCATE.png'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/18 - RCATE.png'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-primary-light); color: white">Journal Article</span>
 <h3 class="pub-title">
               Relational Contracts in Agriculture: Theory and Evidence.
@@ -560,7 +560,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/19 - MMRYP.png'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/19 - MMRYP.png'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-primary-light); color: white">Journal Article</span>
 <h3 class="pub-title">
               Money Matters: The Role of Yields and Profits in Agricultural
@@ -586,7 +586,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/20 - CONSE.png'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/20 - CONSE.png'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-primary-light); color: white">Journal Article</span>
 <h3 class="pub-title">
               Conservation Agriculture and Climate Resilience.
@@ -602,7 +602,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/21 - FGICP.png'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/21 - FGICP.png'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-primary-light); color: white">Journal Article</span>
 <h3 class="pub-title">
               Foreign Geographical Indications, Consumer Preferences, and the
@@ -626,7 +626,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/22 - BFEAA.png'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/22 - BFEAA.png'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-primary-light); color: white">Journal Article</span>
 <h3 class="pub-title">
               Beasts of the Field? Ethics in Agricultural and Applied Economics.
@@ -640,7 +640,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/23 - FICRM.png'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/23 - FICRM.png'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-primary-light); color: white">Journal Article</span>
 <h3 class="pub-title">
               Fitting and Interpreting Correlated Random-Coefficient Models
@@ -667,7 +667,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/24 - SDADP.png'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/24 - SDADP.png'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-primary-light); color: white">Journal Article</span>
 <h3 class="pub-title">
               To Specialize or Diversify: Agricultural Diversity and Poverty
@@ -682,7 +682,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/25 - ISDPS.jpg'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/25 - ISDPS.jpg'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-primary-light); color: white">Journal Article</span>
 <h3 class="pub-title">
               The Importance of the Savings Device in Precautionary Savings:
@@ -697,7 +697,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/26 - WIICA.png'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/26 - WIICA.png'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-primary-light); color: white">Journal Article</span>
 <h3 class="pub-title">
               Welfare Impacts of Improved Chickpea Adoption: A Pathway for Rural
@@ -714,7 +714,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/27 - LTTSF.png'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/27 - LTTSF.png'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-primary-light); color: white">Journal Article</span>
 <h3 class="pub-title">
               Land Tenure, Tenure Security and Farm Efficiency: Panel Evidence
@@ -749,7 +749,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/28 - RDIPA.png'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/28 - RDIPA.png'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-accent); color: white">Book Chapter</span>
 <h3 class="pub-title">
               Recent Developments in Inference: Practicalities for the Applied
@@ -765,7 +765,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/29 - EICFA.png'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/29 - EICFA.png'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-accent); color: white">Book Chapter</span>
 <h3 class="pub-title">
               The Evolving Impact of COVID-19 in Four African Countries
@@ -786,7 +786,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/30 - UMWEO.png'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/30 - UMWEO.png'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-secondary); color: white">Working Paper</span>
 <h3 class="pub-title">
               The Uses (and Misuses) of Weather and Earth Observation Data in
@@ -800,7 +800,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/31 - CRISD.png'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/31 - CRISD.png'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-secondary); color: white">Working Paper</span>
 <h3 class="pub-title">
               Considerations and Resources for Integrating EO and Socioeconomic
@@ -815,7 +815,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/32 - MMCAR.png'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/32 - MMCAR.png'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-secondary); color: white">Working Paper</span>
 <h3 class="pub-title">
               Mining Meaning: Conducting AI-Assisted Reviews of Economic
@@ -829,7 +829,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/33 - VSSAR.png'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/33 - VSSAR.png'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-secondary); color: white">Working Paper</span>
 <h3 class="pub-title">
               Variable Selection in Socioeconomic Applications of Remotely
@@ -843,7 +843,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/34 - LCMEF.png'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/34 - LCMEF.png'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-secondary); color: white">Working Paper</span>
 <h3 class="pub-title">
               Labor, Credit, and Markets: Evidence from the Philippines,
@@ -857,7 +857,7 @@
        color: inherit;
        display: flex;
        flex-direction: column;
-       background-image: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.8)), url('assets/images/publications/35 - RRSSE.png'); background-size: cover; background-position: center;">
+       background-image: linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%), url('assets/images/publications/35 - RRSSE.png'); background-size: cover; background-position: center;">
 <span class="card-tag" style="background-color: var(--color-secondary); color: white">Working Paper</span>
 <h3 class="pub-title">
               Risk and Rainfall: Specification Sensitivity in Estimating


### PR DESCRIPTION
Reverts the publication card background gradients on `publications.html` from a darker shading (introduced in the last merge) to a lighter standard shading: `linear-gradient(to bottom, rgba(15, 23, 42, 0.4) 0%, rgba(15, 23, 42, 0.7) 100%)`. This satisfies the user's preference for the main card layout. Pre-commit tests and visual Playwright UI tests run properly.

---
*PR created automatically by Jules for task [11484509182327364311](https://jules.google.com/task/11484509182327364311) started by @jdavidm*