### PR TITLE
Fix incorrect hero background images on two publication pages

### DIFF
--- a/risk-and-rainfall-specification-sensitivity-estimating-smallholder-risk-preferences.html
+++ b/risk-and-rainfall-specification-sensitivity-estimating-smallholder-risk-preferences.html
@@ -102,7 +102,7 @@
 
     <!-- Page Header -->
     <header class="hero" style="min-height: 50vh">
-      <img src="photos/IMG_7551.webp" alt="Background" class="hero-bg" />
+      <img src="assets/images/publications/35 - RRSSE.png" alt="Background" class="hero-bg" />
       <div
         class="container relative z-10"
         style="max-width: 800px; margin: 0 auto"

--- a/variable-selection-economic-applications-remotely-sensed-weather-data.html
+++ b/variable-selection-economic-applications-remotely-sensed-weather-data.html
@@ -102,7 +102,7 @@
 
     <!-- Page Header -->
     <header class="hero" style="min-height: 50vh">
-      <img src="photos/IMG_7551.webp" alt="Background" class="hero-bg" />
+      <img src="assets/images/publications/33 - VSSAR.png" alt="Background" class="hero-bg" />
       <div
         class="container relative z-10"
         style="max-width: 800px; margin: 0 auto"


### PR DESCRIPTION
Update the hero background image src to match the corresponding publication card images for the following pages:
- `variable-selection-economic-applications-remotely-sensed-weather-data.html`
- `risk-and-rainfall-specification-sensitivity-estimating-smallholder-risk-preferences.html`

---
*PR created automatically by Jules for task [8133124064232005718](https://jules.google.com/task/8133124064232005718) started by @jdavidm*