### PR TITLE
🔒 Fix insecure HTTP link in World Bank references

### DIFF
--- a/coping-or-hoping.html
+++ b/coping-or-hoping.html
@@ -170,7 +170,7 @@
               >REPLICATION</a
             >
             <a
-              href="http://documents.worldbank.org/curated/en/099830101072519538/IDU1b45f8bf4104061493a18b9e12cfbee039761"
+              href="https://documents.worldbank.org/curated/en/099830101072519538/IDU1b45f8bf4104061493a18b9e12cfbee039761"
               rel="noopener noreferrer"
               target="_blank"
               >PREPRINT</a

--- a/mismeasure-weather.html
+++ b/mismeasure-weather.html
@@ -170,7 +170,7 @@
               >REPLICATION</a
             >
             <a
-              href="http://documents.worldbank.org/curated/en/099850401072516334/IDU16cb26542195d814cc21b3191ae81d19d57ec"
+              href="https://documents.worldbank.org/curated/en/099850401072516334/IDU16cb26542195d814cc21b3191ae81d19d57ec"
               rel="noopener noreferrer"
               target="_blank"
               >PREPRINT</a


### PR DESCRIPTION
🎯 **What:** The World Bank document links in `mismeasure-weather.html` and `coping-or-hoping.html` were using `http://` instead of `https://`.
⚠️ **Risk:** Using HTTP for document links makes them susceptible to Man-in-the-Middle (MitM) attacks where the downloaded document could be replaced or intercepted.
🛡️ **Solution:** Changed the URLs from `http://` to `https://` since the World Bank domain supports secure connections.

---
*PR created automatically by Jules for task [17084441773277097376](https://jules.google.com/task/17084441773277097376) started by @jdavidm*